### PR TITLE
Add offset parameter

### DIFF
--- a/butane_core/src/db/connmethods.rs
+++ b/butane_core/src/db/connmethods.rs
@@ -18,6 +18,7 @@ pub trait ConnectionMethods {
         columns: &'b [Column],
         expr: Option<BoolExpr>,
         limit: Option<i32>,
+        offset: Option<i32>,
         sort: Option<&[Order]>,
     ) -> Result<RawQueryResult<'a>>;
     fn insert_returning_pk(

--- a/butane_core/src/db/helper.rs
+++ b/butane_core/src/db/helper.rs
@@ -165,6 +165,10 @@ pub fn sql_limit(limit: i32, w: &mut impl Write) {
     write!(w, " LIMIT {}", limit).unwrap();
 }
 
+pub fn sql_offset(offset: i32, w: &mut impl Write) {
+    write!(w, " OFFSET {}", offset).unwrap();
+}
+
 pub fn sql_order(order: &[Order], w: &mut impl Write) {
     write!(w, " ORDER BY ").unwrap();
     order.iter().fold("", |sep, o| {

--- a/butane_core/src/db/macros.rs
+++ b/butane_core/src/db/macros.rs
@@ -11,10 +11,11 @@ macro_rules! connection_method_wrapper {
                 columns: &'b [Column],
                 expr: Option<BoolExpr>,
                 limit: Option<i32>,
+                offset: Option<i32>,
                 sort: Option<&[crate::query::Order]>,
             ) -> Result<RawQueryResult<'a>> {
                 self.wrapped_connection_methods()?
-                    .query(table, columns, expr, limit, sort)
+                    .query(table, columns, expr, limit, offset, sort)
             }
             fn insert_returning_pk(
                 &self,

--- a/butane_core/src/db/pg.rs
+++ b/butane_core/src/db/pg.rs
@@ -131,6 +131,7 @@ where
         columns: &'b [Column],
         expr: Option<BoolExpr>,
         limit: Option<i32>,
+        offset: Option<i32>,
         order: Option<&[query::Order]>,
     ) -> Result<RawQueryResult<'a>> {
         let mut sqlquery = String::new();
@@ -152,6 +153,10 @@ where
 
         if let Some(limit) = limit {
             helper::sql_limit(limit, &mut sqlquery)
+        }
+
+        if let Some(offset) = offset {
+            helper::sql_offset(offset, &mut sqlquery)
         }
 
         if cfg!(feature = "log") {

--- a/butane_core/src/db/sqlite.rs
+++ b/butane_core/src/db/sqlite.rs
@@ -110,6 +110,7 @@ impl ConnectionMethods for rusqlite::Connection {
         columns: &'b [Column],
         expr: Option<BoolExpr>,
         limit: Option<i32>,
+        offset: Option<i32>,
         order: Option<&[Order]>,
     ) -> Result<RawQueryResult<'a>> {
         let mut sqlquery = String::new();
@@ -131,6 +132,10 @@ impl ConnectionMethods for rusqlite::Connection {
 
         if let Some(limit) = limit {
             helper::sql_limit(limit, &mut sqlquery)
+        }
+
+        if let Some(offset) = offset {
+            helper::sql_offset(offset, &mut sqlquery)
         }
 
         debug!("query sql {}", sqlquery);

--- a/butane_core/src/migrations/mod.rs
+++ b/butane_core/src/migrations/mod.rs
@@ -86,6 +86,7 @@ pub trait Migrations {
                 None,
                 None,
                 None,
+                None,
             )?
             .mapped(ButaneMigration::from_row)
             .collect()?;

--- a/butane_core/src/query/mod.rs
+++ b/butane_core/src/query/mod.rs
@@ -152,6 +152,8 @@ impl<T: DataResult> Query<T> {
         self
     }
 
+    ///Skips the first `off` objects before returning them. Returns
+    /// `self` as this method is expected to be chained.
     pub fn offset(mut self, off: i32) -> Query<T> {
         self.offset = Some(off);
         self

--- a/butane_core/src/query/mod.rs
+++ b/butane_core/src/query/mod.rs
@@ -118,6 +118,7 @@ pub struct Query<T: DataResult> {
     table: TblName,
     filter: Option<BoolExpr>,
     limit: Option<i32>,
+    offset: Option<i32>,
     sort: Vec<Order>,
     phantom: PhantomData<T>,
 }
@@ -130,6 +131,7 @@ impl<T: DataResult> Query<T> {
             table: Cow::Borrowed(table),
             filter: None,
             limit: None,
+            offset: None,
             sort: Vec::new(),
             phantom: PhantomData,
         }
@@ -171,7 +173,7 @@ impl<T: DataResult> Query<T> {
 
     /// Executes the query against `conn` and returns the first result (if any).
     pub fn load_first(self, conn: &impl ConnectionMethods) -> Result<Option<T>> {
-        conn.query(&self.table, T::COLUMNS, self.filter, Some(1), None)?
+        conn.query(&self.table, T::COLUMNS, self.filter, Some(1), None, None)?
             .mapped(T::from_row)
             .nth(0)
     }
@@ -183,7 +185,7 @@ impl<T: DataResult> Query<T> {
         } else {
             Some(self.sort.as_slice())
         };
-        conn.query(&self.table, T::COLUMNS, self.filter, self.limit, sort)?
+        conn.query(&self.table, T::COLUMNS, self.filter, self.limit, self.offset, sort)?
             .mapped(T::from_row)
             .collect()
     }

--- a/butane_core/src/query/mod.rs
+++ b/butane_core/src/query/mod.rs
@@ -152,6 +152,11 @@ impl<T: DataResult> Query<T> {
         self
     }
 
+    pub fn offset(mut self, off: i32) -> Query<T> {
+        self.offset = Some(off);
+        self
+    }
+
     /// Order the query results by the given column. Multiple calls to
     /// this method may be made, with earlier calls taking precedence.
     /// It is recommended to use the `colname!`


### PR DESCRIPTION
Offset allows you to skip a certain number of records before returning the result. This can be useful when requesting the next page of records if a limit is set.
 
Example
```rust
pub fn article_list(limit: i32, offset: i32, conn: &Connection) -> Result<Vec<ArticleOutput>, Error>
{
    let res = Query::<Article>::new("article")
        .limit(limit)
        .offset(offset)
        .load(conn);
    match res {
        Ok(articles) => {
            let mut result : Vec<ArticleOutput> = vec!();
            for article in articles {
                result.push(article.to_result(conn));
            }
            Ok(result)
        },
        Err(err) => return Err(err)
    }
}
```