### PR TITLE
Reexposes r2d2::ManageConnection in r2

### DIFF
--- a/butane_core/src/db/mod.rs
+++ b/butane_core/src/db/mod.rs
@@ -30,7 +30,7 @@ pub mod pg;
 pub mod sqlite;
 
 #[cfg(feature = "r2d2")]
-mod r2;
+pub mod r2;
 #[cfg(feature = "r2d2")]
 pub use r2::ConnectionManager;
 

--- a/butane_core/src/db/r2.rs
+++ b/butane_core/src/db/r2.rs
@@ -1,6 +1,7 @@
 use super::connmethods::ConnectionMethodWrapper;
 use super::*;
 use crate::Result;
+pub use r2d2::ManageConnection;
 
 /// R2D2 support for Butane. Implements [`r2d2::ManageConnection`].
 pub struct ConnectionManager {
@@ -12,7 +13,7 @@ impl ConnectionManager {
     }
 }
 
-impl r2d2::ManageConnection for ConnectionManager {
+impl ManageConnection for ConnectionManager {
     type Connection = Connection;
     type Error = crate::Error;
 


### PR DESCRIPTION
This change is done to prevent having to add r2d2 dependency directly to Cargo.toml. 

## Previous usage:

```
# Cargo.toml

[dependencies]
butane = { version = "0.5.1", features = ["default", "r2d2"] }
r2d2 = "0.8.10"
```

```
use butane::db::ConnectionManager;
use r2d2::ManageConnection;
```

## New usage:

```
# Cargo.toml

[dependencies]
butane = { version = "0.5.1", features = ["default", "r2d2"] }
```

```
use butane::db::{ConnectionManager, ManageConnection};
```
