### PR TITLE
Allow feature postgres without chrono

### DIFF
--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Electron100/butane"
 
 
 [features]
-datetime = ["chrono"]
+datetime = ["chrono", "postgres?/with-chrono-0_4"]
 debug = ["log"]
 sqlite = ["rusqlite"]
 sqlite-bundled = ["rusqlite/bundled"]
@@ -28,7 +28,7 @@ hex = "0.4"
 once_cell="1.5"
 log = { version="0.4", optional=true }
 native-tls={ version = "0.2", optional = true }
-postgres={ version = "0.19", features=["with-chrono-0_4"], optional = true}
+postgres={ version = "0.19", optional = true}
 postgres-native-tls={ version = "0.5", optional = true }
 proc-macro2 = "1.0"
 pin-project = "1"


### PR DESCRIPTION
New since Rust 1.60 https://doc.rust-lang.org/cargo/reference/features.html#dependency-features