### PR TITLE
Tidy toml

### DIFF
--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -30,21 +30,21 @@ butane_core = { path = "../butane_core", version = "0.5" }
 
 [dev-dependencies]
 cfg-if = "1.0"
-exec_time = { version="0.1.4" }
+exec_time = { version = "0.1.4" }
 paste = "1.0.11"
-chrono = { version = "0.4", features=["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 env_logger = "0.10"
 geo-types = "0.7"
 libc = "0.2"
-log_for_test = {package="log", version = "0.4"}
+log_for_test = { package = "log", version = "0.4" }
 quote = "1.0"
-proc-macro2="1.0"
-once_cell="1.5.2"
-postgres = { version = "0.19", features=["with-geo-types-0_7"] }
-r2d2_for_test = {package="r2d2", version = "0.8"}
-rusqlite = {workspace=true}
+proc-macro2 = "1.0"
+once_cell = "1.5.2"
+postgres = { version = "0.19", features = ["with-geo-types-0_7"] }
+r2d2_for_test = { package = "r2d2", version = "0.8" }
+rusqlite = { workspace = true }
 serde_json = "1.0"
-uuid_for_test = {package="uuid", version = "1.2", features=["v4"] }
+uuid_for_test = { package = "uuid", version = "1.2", features = ["v4"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/butane_cli/Cargo.toml
+++ b/butane_cli/Cargo.toml
@@ -18,7 +18,11 @@ sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
 anyhow = "1.0"
-butane = { path="../butane", version="0.5", features=["default", "sqlite", "pg"] }
+butane = { path = "../butane", version = "0.5", features = [
+  "default",
+  "sqlite",
+  "pg",
+] }
 chrono = "0.4"
 clap = "2.34"
 quote = "1.0"

--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro2 = "1.0"
 butane_core = { path = "../butane_core", version = "0.5" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-uuid = {workspace=true, optional=true}
+uuid = { workspace = true, optional = true }
 
 [lib]
 proc-macro = true

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -19,26 +19,26 @@ pg = ["postgres", "bytes"]
 
 
 [dependencies]
-bytes = { version="1.0", optional=true}
+bytes = { version = "1.0", optional = true }
 cfg-if = "1.0"
 fallible-iterator = "0.2"
 fallible-streaming-iterator = "0.1"
-fs2 = "0.4" # for file locks
+fs2 = "0.4"                                                         # for file locks
 hex = "0.4"
-once_cell="1.5"
-log = { version="0.4", optional=true }
-native-tls={ version = "0.2", optional = true }
-postgres={ version = "0.19", optional = true}
-postgres-native-tls={ version = "0.5", optional = true }
+once_cell = "1.5"
+log = { version = "0.4", optional = true }
+native-tls = { version = "0.2", optional = true }
+postgres = { version = "0.19", optional = true }
+postgres-native-tls = { version = "0.5", optional = true }
 proc-macro2 = "1.0"
 pin-project = "1"
 quote = "1.0"
 regex = "1.5"
-r2d2 = {version="0.8", optional=true}
-rusqlite = {workspace=true, optional = true}
-serde = { version = "1.0", features=["derive"] }
+r2d2 = { version = "0.8", optional = true }
+rusqlite = { workspace = true, optional = true }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
 thiserror = "1.0"
-chrono = { version = "0.4", features=["serde"], optional = true }
-uuid = {workspace=true, optional=true}
+chrono = { version = "0.4", features = ["serde"], optional = true }
+uuid = { workspace = true, optional = true }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-butane = { path="../butane"}
+butane = { path = "../butane" }
 
 [package.metadata.release]
 release = false

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -21,7 +21,7 @@ doc = false
 doc = false
 
 [dependencies]
-butane = { path = "../../butane", features=["default", "sqlite"] }
+butane = { path = "../../butane", features = ["default", "sqlite"] }
 
 
 [package.metadata.release]


### PR DESCRIPTION
This is the result of running `cargo make format-toml` , which invokes https://github.com/sagiegurari/cargo-make , which invokes https://crates.io/crates/taplo-cli , which has a config file that can be used to alter the way toml files are formatting.

I like to enable `reorder_keys = true`, but that also alpha orders the `[package]` metadata section, and I've found that is an acquired taste.

I am happy to set up CI to enforce this, and even happier to set up a PR to replace `Makefile` with `Makefile.toml`, which has lots of Rust-specific advantages in addition to not using tabs.