### PR TITLE
Alpha sort keys in Cargo.toml files

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,2 +1,8 @@
 [formatting]
 reorder_arrays = true
+reorder_keys = true
+
+# Do not reorder keys within `package or `bin`.
+[[rule]]
+formatting = { reorder_keys = false }
+keys = ["bin", "package"]

--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/Electron100/butane"
 datetime = []
 
 [dependencies]
-proc-macro2 = { version = "1.0", default-features = false }
 butane_core = { path = "../butane_core", version = "0.5" }
+proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
-syn = { version = "1.0", features = [ "extra-traits", "full" ] }
+syn = { version = "1.0", features = ["extra-traits", "full"] }
 uuid = { workspace = true, optional = true }
 
 [lib]

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -13,36 +13,36 @@ repository = "https://github.com/Electron100/butane"
 datetime = ["chrono", "postgres?/with-chrono-0_4"]
 debug = ["log"]
 json = ["postgres?/with-serde_json-1", "rusqlite?/serde_json"]
+pg = ["bytes", "postgres"]
 sqlite = ["rusqlite"]
 sqlite-bundled = ["rusqlite/bundled"]
 tls = ["native-tls", "postgres-native-tls"]
-pg = ["bytes", "postgres"]
 
 
 [dependencies]
 bytes = { version = "1.0", optional = true }
 cfg-if = "1.0"
-fallible-iterator = "0.2"
-fallible-streaming-iterator = "0.1"
-fs2 = "0.4" # for file locks
-hex = "0.4"
-once_cell = "1.5"
-log = { version = "0.4", optional = true }
-native-tls = { version = "0.2", optional = true }
-postgres = { version = "0.19", optional = true }
-postgres-native-tls = { version = "0.5", optional = true }
-proc-macro2 = { version = "1.0", default-features = false }
-pin-project = "1"
-quote = { version = "1.0", default-features = false }
-regex = { version = "1.5", default-features = false, features = ["std"] }
-r2d2 = { version = "0.8", optional = true }
-rusqlite = { workspace = true, optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde_json = "1.0"
-syn = { version = "1.0", features = [ "extra-traits", "full" ] }
-thiserror = "1.0"
 chrono = { version = "0.4", default-features = false, features = [
   "serde",
   "std",
 ], optional = true }
+fallible-iterator = "0.2"
+fallible-streaming-iterator = "0.1"
+fs2 = "0.4" # for file locks
+hex = "0.4"
+log = { version = "0.4", optional = true }
+native-tls = { version = "0.2", optional = true }
+once_cell = "1.5"
+pin-project = "1"
+postgres = { version = "0.19", optional = true }
+postgres-native-tls = { version = "0.5", optional = true }
+proc-macro2 = { version = "1.0", default-features = false }
+quote = { version = "1.0", default-features = false }
+r2d2 = { version = "0.8", optional = true }
+regex = { version = "1.5", default-features = false, features = ["std"] }
+rusqlite = { workspace = true, optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json = "1.0"
+syn = { version = "1.0", features = ["extra-traits", "full"] }
+thiserror = "1.0"
 uuid = { workspace = true, optional = true }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-butane = { path = "../butane", features = [ "sqlite" ] }
+butane = { path = "../butane", features = ["sqlite"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"


### PR DESCRIPTION
Followup to https://github.com/Electron100/butane/pull/39, this uses `reorder_keys`.  No worries if you reject because it also changes the package metadata sections.
If rejected, I'll see if I can find another tool which can reorder only the dependencies.