### PR TITLE
Add a `butane clean` command

### DIFF
--- a/butane_core/src/migrations/fsmigrations.rs
+++ b/butane_core/src/migrations/fsmigrations.rs
@@ -301,6 +301,10 @@ impl MigrationsMut for FsMigrations {
     fn current(&mut self) -> &mut Self::M {
         &mut self.current
     }
+    fn clear_current(&mut self) -> Result<()> {
+        std::fs::remove_dir_all(&self.current.root)?;
+        Ok(())
+    }
     fn new_migration(&self, name: &str) -> Self::M {
         let mut dir = self.root.clone();
         dir.push(name);

--- a/butane_core/src/migrations/memmigrations.rs
+++ b/butane_core/src/migrations/memmigrations.rs
@@ -133,6 +133,11 @@ impl MigrationsMut for MemMigrations {
         &mut self.current
     }
 
+    fn clear_current(&mut self) -> Result<()> {
+        self.current = MemMigration::new("current".to_string());
+        Ok(())
+    }
+
     fn new_migration(&self, name: &str) -> Self::M {
         MemMigration::new(name.to_string())
     }

--- a/butane_core/src/migrations/mod.rs
+++ b/butane_core/src/migrations/mod.rs
@@ -136,6 +136,9 @@ where
     /// - it will never be returned by `latest`, `migrations_since`, `all_migrations` or other similar methods.
     fn current(&mut self) -> &mut Self::M;
 
+    /// Clears the current state (as would be returned by the `current` method).
+    fn clear_current(&mut self) -> Result<()>;
+
     /// Create a migration `from` -> `current` named `name`. From may be None, in which
     /// case the migration is created from an empty database.
     /// Returns true if a migration was created, false if `from` and `current` represent identical states.


### PR DESCRIPTION
Clean current migration state. Deletes the current migration working state which is generated on each build. This can be used as a workaround to remove stale tables from the schema, as Butane does not currently auto-detect model removals. The next build will recreate with only tables for the extant models.

This is a workaround for #44