### PR TITLE
Remove unused features of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,15 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,17 +46,6 @@ dependencies = [
  "proc-macro2 1.0.49",
  "quote 1.0.23",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -209,12 +189,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -224,13 +201,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
  "textwrap",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -342,7 +315,7 @@ dependencies = [
  "ident_case",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "strsim 0.7.0",
+ "strsim",
  "syn 0.15.44",
 ]
 
@@ -589,7 +562,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -615,15 +588,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
  "hashbrown",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -711,7 +675,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.42.0",
@@ -812,7 +776,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.42.0",
 ]
 
@@ -1352,12 +1316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,17 +1393,6 @@ dependencies = [
  "proc-macro2 1.0.49",
  "quote 1.0.23",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -1602,22 +1549,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -33,7 +33,10 @@ butane_core = { path = "../butane_core", version = "0.5" }
 cfg-if = "1.0"
 exec_time = { version = "0.1.4" }
 paste = "1.0.11"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+  "serde",
+  "std",
+] }
 env_logger = "0.10"
 geo-types = "0.7"
 libc = "0.2"

--- a/butane_cli/Cargo.toml
+++ b/butane_cli/Cargo.toml
@@ -23,8 +23,8 @@ butane = { path = "../butane", version = "0.5", features = [
   "pg",
   "sqlite",
 ] }
-chrono = "0.4"
-clap = "2.34"
-quote = "1.0"
-serde = "1.0"
+chrono = { version = "0.4", default-features = false }
+clap = { version = "2.34", default-features = false }
+quote = { version = "1.0", default-features = false }
+serde = { version = "1.0", default-features = false }
 serde_json = "1.0"

--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/Electron100/butane"
 datetime = []
 
 [dependencies]
-proc-macro2 = "1.0"
+proc-macro2 = { version = "1.0", default-features = false }
 butane_core = { path = "../butane_core", version = "0.5" }
-quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits", "full"] }
+quote = { version = "1.0", default-features = false }
+syn = { version = "1.0", default-features = false }
 uuid = { workspace = true, optional = true }
 
 [lib]

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -24,22 +24,28 @@ bytes = { version = "1.0", optional = true }
 cfg-if = "1.0"
 fallible-iterator = "0.2"
 fallible-streaming-iterator = "0.1"
-fs2 = "0.4"                                                         # for file locks
+fs2 = "0.4" # for file locks
 hex = "0.4"
 once_cell = "1.5"
 log = { version = "0.4", optional = true }
 native-tls = { version = "0.2", optional = true }
 postgres = { version = "0.19", optional = true }
 postgres-native-tls = { version = "0.5", optional = true }
-proc-macro2 = "1.0"
+proc-macro2 = { version = "1.0", default-features = false }
 pin-project = "1"
-quote = "1.0"
-regex = "1.5"
+quote = { version = "1.0", default-features = false }
+regex = { version = "1.5", default-features = false, features = ["std"] }
 r2d2 = { version = "0.8", optional = true }
 rusqlite = { workspace = true, optional = true }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
-syn = { version = "1.0", features = ["extra-traits", "full"] }
+syn = { version = "1.0", default-features = false, features = [
+  "extra-traits",
+  "full",
+] }
 thiserror = "1.0"
-chrono = { version = "0.4", features = ["serde"], optional = true }
+chrono = { version = "0.4", default-features = false, features = [
+  "serde",
+  "std",
+], optional = true }
 uuid = { workspace = true, optional = true }


### PR DESCRIPTION
I am especially keen to remove the "time" crate from chrono deps, as it causes cargo-deny to fail due to https://rustsec.org/advisories/RUSTSEC-2020-0071

The one unusual bit here is disabling `perf` in `regex`, but given how little the regex library is used, it seems to not be worthwhile using those extra perf gains https://docs.rs/regex/latest/regex/#performance-features .