### PR TITLE
WIP: Add #[derive(ButaneJson)]

### DIFF
--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -1,4 +1,4 @@
-pub use butane_codegen::{butane_type, dataresult, model};
+pub use butane_codegen::{butane_type, dataresult, model, ButaneJson};
 pub use butane_core::custom;
 pub use butane_core::fkey::ForeignKey;
 pub use butane_core::many::Many;

--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -1,4 +1,4 @@
-pub use butane_codegen::{butane_type, dataresult, model, ButaneJson};
+pub use butane_codegen::{butane_type, dataresult, model, FieldType};
 pub use butane_core::custom;
 pub use butane_core::fkey::ForeignKey;
 pub use butane_core::many::Many;


### PR DESCRIPTION
This makes it easy to mark a struct with `#[butane_type(Json)` and `#[derive(ButaneJson)]` , and then use the struct in a model.

There are likely to be much better ways of doing this.