### PR TITLE
Re-enable default features of syn dependency

### DIFF
--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -15,7 +15,7 @@ datetime = []
 proc-macro2 = { version = "1.0", default-features = false }
 butane_core = { path = "../butane_core", version = "0.5" }
 quote = { version = "1.0", default-features = false }
-syn = { version = "1.0", default-features = false }
+syn = { version = "1.0", features = [ "extra-traits", "full" ] }
 uuid = { workspace = true, optional = true }
 
 [lib]

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -39,10 +39,7 @@ r2d2 = { version = "0.8", optional = true }
 rusqlite = { workspace = true, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
-syn = { version = "1.0", default-features = false, features = [
-  "extra-traits",
-  "full",
-] }
+syn = { version = "1.0", features = [ "extra-traits", "full" ] }
 thiserror = "1.0"
 chrono = { version = "0.4", default-features = false, features = [
   "serde",


### PR DESCRIPTION
Bug in https://github.com/Electron100/butane/pull/47

At least `parsing` and `printing` are needed, only visible if the target project doesnt have `syn` in the dependency tree.