### PR TITLE
More flexibility in accepting DateTime identifiers

### DIFF
--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -98,6 +98,7 @@ struct TimeHolder {
     pub id: i32,
     pub naive: NaiveDateTime,
     pub utc: DateTime<Utc>,
+    pub utc2: chrono::DateTime<Utc>,
 }
 
 fn basic_crud(conn: Connection) {
@@ -336,6 +337,7 @@ fn basic_time(conn: Connection) {
         id: 1,
         naive: now.naive_utc(),
         utc: now,
+        utc2: now,
         state: ObjectState::default(),
     };
     time.save(&conn).unwrap();

--- a/butane_core/src/codegen/mod.rs
+++ b/butane_core/src/codegen/mod.rs
@@ -483,7 +483,7 @@ fn last_path_segment(ty: &syn::Type) -> Option<&syn::PathSegment> {
     {
         return segments.last();
     }
-    return None;
+    None
 }
 
 fn template_type(arguments: &syn::PathArguments) -> Option<&Ident> {
@@ -497,7 +497,7 @@ fn template_type(arguments: &syn::PathArguments) -> Option<&Ident> {
             }
         }
     }
-    return None;
+    None
 }
 
 fn has_derive_serialize(attrs: &[Attribute]) -> bool {


### PR DESCRIPTION
Allows `chrono::DateTime` alongside `DateTime`
Fixes #53

The real issue here is that the migration type resolution is relying on the proc macro, which sees only the AST and not the type system. So when it sees a type identifier, it sees the path segments that are in the AST, not the actual type, meaning that `chrono::DateTime` and `DateTime` (after `use chrono::DateTime`) are not the same! The latter was getting accepted and the former is not.

This PR is a bandaid to discard the path information and just look at the last segment (hoping it was imported from chrono!) to make this slightly more flexible.

This type of issue is the biggest reason I want to move migration generation from proc-macro time to something triggered by the `butane` cli command.