### PR TITLE
Add #[derive(FieldType)]

### DIFF
--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 [features]
 default = ["datetime", "json", "uuid"]
 fake = ["butane_core/fake"]
-json = ["butane_core/json"]
+json = ["butane_core/json", "butane_codegen/datetime"]
 sqlite = ["butane_core/sqlite"]
 sqlite-bundled = ["butane_core/sqlite-bundled"]
 pg = ["butane_core/pg"]

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 [features]
 default = ["datetime", "json", "uuid"]
 fake = ["butane_core/fake"]
-json = ["butane_core/json", "butane_codegen/datetime"]
+json = ["butane_core/json", "butane_codegen/json"]
 sqlite = ["butane_core/sqlite"]
 sqlite-bundled = ["butane_core/sqlite-bundled"]
 pg = ["butane_core/pg"]

--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -1,4 +1,4 @@
-pub use butane_codegen::{butane_type, dataresult, model};
+pub use butane_codegen::{butane_type, dataresult, model, ButaneJson};
 pub use butane_core::custom;
 pub use butane_core::fkey::ForeignKey;
 pub use butane_core::many::Many;

--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -1,4 +1,4 @@
-pub use butane_codegen::{butane_type, dataresult, model, ButaneJson};
+pub use butane_codegen::{butane_type, dataresult, model, FieldType};
 pub use butane_core::custom;
 pub use butane_core::fkey::ForeignKey;
 pub use butane_core::many::Many;

--- a/butane/tests/json.rs
+++ b/butane/tests/json.rs
@@ -157,7 +157,6 @@ fn hashmap_with_object_values(conn: Connection) {
 }
 testall!(hashmap_with_object_values);
 
-#[butane_type(Json)]
 #[derive(PartialEq, Eq, Debug, Clone, FieldType, Serialize, Deserialize)]
 struct InlineFoo {
     foo: i64,

--- a/butane/tests/json.rs
+++ b/butane/tests/json.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use butane::model;
 use butane::prelude::*;
-use butane::{butane_type, db::Connection, FieldType, ObjectState};
+use butane::{db::Connection, FieldType, ObjectState};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Electron100/butane"
 
 [features]
 datetime = []
+json = ["butane_core/json"]
 
 [dependencies]
 butane_core = { path = "../butane_core", version = "0.5" }

--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -3,11 +3,7 @@
 
 extern crate proc_macro;
 
-use butane_core::SqlType;
-use butane_core::{
-    codegen, make_compile_error, migrations,
-    migrations::adb::{DeferredSqlType, TypeIdentifier},
-};
+use butane_core::{codegen, make_compile_error, migrations};
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2::TokenTree;
@@ -175,7 +171,13 @@ fn migrations_dir() -> PathBuf {
 #[proc_macro_derive(FieldType)]
 pub fn derive_field_type(input: TokenStream) -> TokenStream {
     let ast = syn::parse_macro_input!(input as syn::DeriveInput);
-    let struct_name = &ast.ident;
+    derive_field_type_with_json(&ast.ident)
+}
+
+#[cfg(feature = "json")]
+fn derive_field_type_with_json(struct_name: &Ident) -> TokenStream {
+    use butane_core::migrations::adb::{DeferredSqlType, TypeIdentifier};
+    use butane_core::SqlType;
 
     let mut migrations = migrations_for_dir();
 
@@ -215,4 +217,9 @@ pub fn derive_field_type(input: TokenStream) -> TokenStream {
         }
     )
     .into()
+}
+
+#[cfg(not(feature = "json"))]
+fn derive_field_type_with_json(_struct_name: &Ident) -> TokenStream {
+    panic!("Feature 'json' is required to derive FieldType")
 }

--- a/butane_core/src/codegen/mod.rs
+++ b/butane_core/src/codegen/mod.rs
@@ -538,7 +538,8 @@ struct CustomTypeInfo {
     ty: DeferredSqlType,
 }
 
-fn add_custom_type<M>(
+/// Records the SqlType of a custom named type to the current migration.
+pub fn add_custom_type<M>(
     ms: &mut impl MigrationsMut<M = M>,
     name: String,
     ty: DeferredSqlType,


### PR DESCRIPTION
Add the ability to write `#[derive(FieldType)]` on a struct. The struct will be serialized as JSON. In the future, we may expand the capabilities here (for example, to allow deriving `FieldType` on an enum)

Based on #49  from @jayvdb. The majority of the credit for this feature is to him. 