### PR TITLE
Derive FieldType for simple enums

### DIFF
--- a/butane/tests/custom_enum_derived.rs
+++ b/butane/tests/custom_enum_derived.rs
@@ -1,0 +1,86 @@
+// Tests deriving FieldType for an enum
+use butane::db::Connection;
+use butane::prelude::*;
+use butane::{butane_type, model, query};
+use butane::{FieldType, FromSql, ObjectState, SqlVal, ToSql};
+
+use butane_test_helper::*;
+
+#[butane_type(Text)]
+#[derive(PartialEq, Eq, Debug, Clone, FieldType)]
+enum Whatsit {
+    Foo,
+    Bar,
+    Baz,
+}
+
+#[model]
+#[derive(PartialEq, Eq, Debug, Clone)]
+struct HasCustomField2 {
+    id: i64,
+    frob: Whatsit,
+}
+impl HasCustomField2 {
+    fn new(id: i64, frob: Whatsit) -> Self {
+        HasCustomField2 {
+            id,
+            frob,
+            state: ObjectState::default(),
+        }
+    }
+}
+
+fn roundtrip_custom_type(conn: Connection) {
+    //create
+    let mut obj = HasCustomField2::new(1, Whatsit::Foo);
+    obj.save(&conn).unwrap();
+
+    // read
+    let obj2 = HasCustomField2::get(&conn, 1).unwrap();
+    assert_eq!(obj, obj2);
+}
+testall!(roundtrip_custom_type);
+
+fn query_custom_type(conn: Connection) {
+    //create
+    let mut obj_foo = HasCustomField2::new(1, Whatsit::Foo);
+    obj_foo.save(&conn).unwrap();
+    let mut obj_bar = HasCustomField2::new(2, Whatsit::Bar);
+    obj_bar.save(&conn).unwrap();
+
+    // query
+    let results = query!(HasCustomField2, frob == { Whatsit::Bar })
+        .load(&conn)
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0], obj_bar)
+}
+testall!(query_custom_type);
+
+#[test]
+fn enum_to_sql() {
+    assert_eq!(SqlVal::Text("Foo".to_string()), Whatsit::Foo.to_sql());
+    assert_eq!(SqlVal::Text("Bar".to_string()), Whatsit::Bar.to_sql());
+    assert_eq!(SqlVal::Text("Baz".to_string()), Whatsit::Baz.to_sql());
+}
+
+#[test]
+fn enum_from_sql() {
+    assert_eq!(
+        Whatsit::Foo,
+        Whatsit::from_sql(SqlVal::Text("Foo".to_string())).unwrap()
+    );
+    assert_eq!(
+        Whatsit::Bar,
+        Whatsit::from_sql(SqlVal::Text("Bar".to_string())).unwrap()
+    );
+    assert_eq!(
+        Whatsit::Baz,
+        Whatsit::from_sql(SqlVal::Text("Baz".to_string())).unwrap()
+    );
+    match Whatsit::from_sql(SqlVal::Text("Nope".to_string())) {
+        Ok(_) => panic!("Not a valid enum variant"),
+        Err(butane::Error::UnknownEnumVariant(_)) => {} // OK
+        Err(_) => panic!("Unexpected error"),
+    }
+}

--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -170,8 +170,82 @@ fn migrations_dir() -> PathBuf {
 
 #[proc_macro_derive(FieldType)]
 pub fn derive_field_type(input: TokenStream) -> TokenStream {
-    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
-    derive_field_type_with_json(&ast.ident)
+    let derive_input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let ident = &derive_input.ident;
+    match derive_input.data {
+        syn::Data::Struct(_) => derive_field_type_with_json(ident),
+        syn::Data::Enum(data_enum) => derive_field_type_for_enum(ident, data_enum),
+        syn::Data::Union(_) => panic!("Cannot derive FieldType for a union"),
+    }
+}
+
+fn derive_field_type_for_enum(ident: &Ident, data_enum: syn::DataEnum) -> TokenStream {
+    data_enum.variants.iter().for_each(|variant| {
+        if variant.fields != syn::Fields::Unit {
+            panic!("Only simple enums are supported when deriving FieldType")
+        }
+    });
+    let match_arms_to_string: Vec<TokenStream2> = data_enum
+        .variants
+        .iter()
+        .map(|variant| {
+            let v_ident = &variant.ident;
+            let ident_literal = codegen::make_lit(&v_ident.to_string());
+            quote!(Self::#v_ident => #ident_literal,)
+        })
+        .collect();
+    let match_arms_from_string: Vec<TokenStream2> = data_enum
+        .variants
+        .iter()
+        .map(|variant| {
+            let v_ident = &variant.ident;
+            let ident_literal = codegen::make_lit(&v_ident.to_string());
+            quote!(#ident_literal => Ok(Self::#v_ident),)
+        })
+        .collect();
+    quote!(
+        impl #ident {
+            fn to_string_for_butane(&self) -> &'static str {
+                match self {
+                    #(#match_arms_to_string)*
+                }
+            }
+            fn from_string_for_butane(s: &str) -> std::result::Result<Self, butane::Error> {
+                match s {
+                    #(#match_arms_from_string)*
+                    _ => Err(butane::Error::UnknownEnumVariant(s.to_string()))
+                }
+            }
+        }
+        impl butane::ToSql for #ident
+        {
+            fn to_sql(&self) -> butane::SqlVal {
+                butane::SqlVal::Text(self.to_string_for_butane().to_string())
+            }
+            fn to_sql_ref(&self) -> butane::SqlValRef<'_> {
+                butane::SqlValRef::Text(self.to_string_for_butane())
+            }
+        }
+
+        impl butane::FromSql for #ident
+        {
+            fn from_sql_ref(val: butane::SqlValRef) -> std::result::Result<Self, butane::Error> {
+                if let butane::SqlValRef::Text(v) = val {
+                    return Self::from_string_for_butane(v);
+                }
+                Err(butane::Error::CannotConvertSqlVal(
+                    butane::SqlType::Text,
+                    val.into(),
+                ))
+            }
+        }
+        impl butane::FieldType for #ident
+        {
+            type RefType = Self;
+            const SQLTYPE: butane::SqlType = butane::SqlType::Text;
+        }
+    )
+    .into()
 }
 
 #[cfg(feature = "json")]
@@ -200,7 +274,7 @@ fn derive_field_type_with_json(struct_name: &Ident) -> TokenStream {
 
         impl butane::FromSql for #struct_name
         {
-            fn from_sql_ref(val: butane::SqlValRef) -> Result<Self, butane::Error> {
+            fn from_sql_ref(val: butane::SqlValRef) -> std::result::Result<Self, butane::Error> {
                 if let butane::SqlValRef::Json(v) = val {
                     return Ok(#struct_name::deserialize(v).unwrap());
                 }

--- a/butane_core/src/codegen/mod.rs
+++ b/butane_core/src/codegen/mod.rs
@@ -199,7 +199,7 @@ where
 
 fn make_ident_literal_str(ident: &Ident) -> LitStr {
     let as_str = format!("{ident}");
-    LitStr::new(&as_str, Span::call_site())
+    make_lit(&as_str)
 }
 
 pub fn make_lit(s: &str) -> LitStr {

--- a/butane_core/src/lib.rs
+++ b/butane_core/src/lib.rs
@@ -163,6 +163,8 @@ pub enum Error {
     InvalidAuto(String),
     #[error("No implicit default available for custom sql types.")]
     NoCustomDefault,
+    #[error("No enum variant named '{0}'")]
+    UnknownEnumVariant(String),
     #[error("Backend {1} is not compatible with custom SqlVal {0:?}")]
     IncompatibleCustom(custom::SqlValCustom, &'static str),
     #[error("Backend {1} is not compatible with custom SqlType {0:?}")]


### PR DESCRIPTION
Support automatic deriving of `FieldType` for simple enums. The database representation is the string form of the variant name. This builds on the capability from #68 

Fixes #20

Future work could allow an option to use discriminant value instead of name.