### PR TITLE
Fix no-op build perf with build.rs

### DIFF
--- a/butane/build.rs
+++ b/butane/build.rs
@@ -12,5 +12,5 @@ fn main() {
     }
     // Re-create the directory. Only tests populate it and if it is left non-existent
     // Cargo will detect it as changed and a no-op build will not in fact no-op
-    std::fs::create_dir(&dir).unwrap();
+    std::fs::create_dir(dir).unwrap();
 }

--- a/butane/build.rs
+++ b/butane/build.rs
@@ -10,4 +10,7 @@ fn main() {
     if std::path::Path::new(&dir).exists() {
         std::fs::remove_dir_all(dir).unwrap();
     }
+    // Re-create the directory. Only tests populate it and if it is left non-existent
+    // Cargo will detect it as changed and a no-op build will not in fact no-op
+    std::fs::create_dir(&dir).unwrap();
 }


### PR DESCRIPTION
Running `cargo build`, followed by a second `cargo build` should result in the second no-oping and succeeding in a fraction of a second.

`build.rs` removes the `.butane` directory, and `cargo` always treats a non-existent directory as changed. Because this directory is only created when building tests, this behavior leads to what should be a no-op not in fact being so.

We fix this by ensuring we always create the directory.