### PR TITLE
Example docs: use cargo commands where possible

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -3,10 +3,11 @@
 To use this example, build the entire project using `cargo build` in the project root,
 and then run these commands in this directory:
 
-1. Initialise a Sqlite database using `../target/debug/butane init sqlite db.sqlite`
-2. Initialise the migrations using `../target/debug/butane makemigration initial`
-3. Migrate the new sqlite database using `../target/debug/butane migrate`
+1. Initialise a Sqlite database using `cargo run -p butane_cli init sqlite db.sqlite`
+2. Initialise the migrations using `cargo run -p butane_cli makemigration initial`
+3. Migrate the new sqlite database using `cargo run -p butane_cli migrate`
 4. Run the example `../target/debug/example`
 
-Any use of `cargo` will likely delete & recreate the `example/.butane` directory,
-and the above steps will need to be repeated.
+Any use of `cargo` to build/run this project will likely delete &
+recreate the `example/.butane` directory, and the above steps will
+need to be repeated.

--- a/examples/getting_started/README.md
+++ b/examples/getting_started/README.md
@@ -3,6 +3,6 @@
 To use this example, build the entire project using `cargo build` in the project root,
 and then run these commands in this directory:
 
-1. Initialise a Sqlite database using `../../target/debug/butane init sqlite db.sqlite`
-2. Migrate the new sqlite database using `../../target/debug/butane migrate`
-3. Run the commands, such as `../../target/debug/write_post`
+1. Initialise a Sqlite database using `cargo run -p butane_cli init sqlite db.sqlite`
+2. Migrate the new sqlite database using `cargo run -p butane_cli migrate`
+3. Run the commands, such as `cargo run --bin write_post`


### PR DESCRIPTION
Prefer `cargo` commands to relying on specific paths in the `target` directory.