### PR TITLE
Fix publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 butane = { version = "0.6", path = "butane" }
 butane_core = { version = "0.6", path = "butane_core" }
 butane_codegen = { version = "0.6", path = "butane_codegen" }
-butane_test_helper = { version = "0.6", path = "butane_test_helper" }
+butane_test_helper = { path = "butane_test_helper" }
 cfg-if = "^1.0"
 chrono = { version = "0.4", default-features = false, features = [
   "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 [workspace.dependencies]
 butane = { path = "butane" }
 butane_core = { version = "0.6", path = "butane_core" }
+butane_codegen = { version = "0.6", path = "butane_codegen" }
 butane_test_helper = { version = "0.6", path = "butane_test_helper" }
 cfg-if = "^1.0"
 chrono = { version = "0.4", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 edition = "2021"
 
 [workspace.dependencies]
-butane = { path = "butane" }
+butane = { version = "0.6", path = "butane" }
 butane_core = { version = "0.6", path = "butane_core" }
 butane_codegen = { version = "0.6", path = "butane_codegen" }
 butane_test_helper = { version = "0.6", path = "butane_test_helper" }

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -27,7 +27,7 @@ tls = ["butane_core/tls"]
 uuid = ["butane_codegen/uuid", "butane_core/uuid"]
 
 [dependencies]
-butane_codegen = { path = "../butane_codegen" }
+butane_codegen = { workspace = true }
 butane_core = { workspace = true }
 
 [dev-dependencies]

--- a/butane_test_helper/Cargo.toml
+++ b/butane_test_helper/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["James Oakley <james@electronstudio.org>"]
 edition.workspace = true
 description = "A test helper for butane"
 publish = false
+keywords = ["database", "pg", "test"]
+categories = ["database"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Electron100/butane"
+documentation = "https://docs.rs/butane/"
 
 [dependencies]
 butane_core = { features = ["pg", "sqlite"], workspace = true }

--- a/butane_test_helper/Cargo.toml
+++ b/butane_test_helper/Cargo.toml
@@ -17,3 +17,6 @@ libc = "0.2"
 once_cell = { workspace = true }
 postgres = { features = ["with-geo-types-0_7"], workspace = true }
 uuid = { features = ["v4"], workspace = true }
+
+[package.metadata.release]
+release = false

--- a/butane_test_helper/Cargo.toml
+++ b/butane_test_helper/Cargo.toml
@@ -5,11 +5,6 @@ authors = ["James Oakley <james@electronstudio.org>"]
 edition.workspace = true
 description = "A test helper for butane"
 publish = false
-keywords = ["database", "pg", "test"]
-categories = ["database"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/Electron100/butane"
-documentation = "https://docs.rs/butane/"
 
 [dependencies]
 butane_core = { features = ["pg", "sqlite"], workspace = true }


### PR DESCRIPTION
Fix publishing with `cargo release`
1. Fix version specifications for in-repo packages in workspace Cargo.toml
2. Don't release butane_test_helper
3. Don't specify version for `butane_test_helper` when referencing it. This allows `butane_core` to be published despite the circular dev-dependency. See https://github.com/rust-lang/cargo/pull/7333