### PR TITLE
Update dependencies for resolver "2"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,6 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 2.0.15",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
   "butane",
   "butane_cli",

--- a/butane_cli/Cargo.toml
+++ b/butane_cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "butane_cli"
 version = "0.6.0"
 authors = ["James Oakley <james@electronstudio.org>"]
-edition = "2018"
+edition.workspace = true
 description = "The CLI for the Butane ORM"
 readme = "../README.md"
 license = "MIT OR Apache-2.0"

--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -9,15 +9,15 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Electron100/butane"
 
 [features]
-datetime = []
+datetime = ["butane_core/datetime"]
 json = ["butane_core/json"]
+uuid = ["butane_core/uuid"]
 
 [dependencies]
 butane_core = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
-uuid = { workspace = true, optional = true }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
The tests fail when using `resolver = "2"`.
https://doc.rust-lang.org/cargo/reference/resolver.html?highlight=resolver#resolver-versions
This seems to do the trick. 