### PR TITLE
Fix docs.rs build

### DIFF
--- a/butane/build.rs
+++ b/butane/build.rs
@@ -8,9 +8,13 @@ fn main() {
     let dir = ".butane/";
     println!("cargo:rerun-if-changed={dir}");
     if std::path::Path::new(&dir).exists() {
-        std::fs::remove_dir_all(dir).unwrap();
+        match std::fs::remove_dir_all(dir) {
+            Ok(_) => {
+                // Re-create the directory. Only tests populate it and if it is left non-existent
+                // Cargo will detect it as changed and a no-op build will not in fact no-op
+                std::fs::create_dir(dir).unwrap();
+            }
+            Err(_) => eprintln!("Cannot delete .butane dir"),
+        }
     }
-    // Re-create the directory. Only tests populate it and if it is left non-existent
-    // Cargo will detect it as changed and a no-op build will not in fact no-op
-    std::fs::create_dir(dir).unwrap();
 }


### PR DESCRIPTION
Docs.rs build broke for 0.6 due to the build.rs script which attempted to perform read operations on the source filesystem. Docs.rs checks out the source to a read-only filesystem.