### PR TITLE
WIP: Auto-save Many new_values items

### DIFF
--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/butane/"
 build = "build.rs"
 
 [features]
+auto-save-related = ["butane_core/auto-save-related"]
 default = ["datetime", "json", "uuid"]
 fake = ["butane_core/fake"]
 json = ["butane_codegen/json", "butane_core/json"]

--- a/butane/tests/common/blog.rs
+++ b/butane/tests/common/blog.rs
@@ -7,7 +7,7 @@ use chrono::{naive::NaiveDateTime, offset::Utc};
 use fake::Dummy;
 
 #[model]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "fake", derive(Dummy))]
 pub struct Blog {
     pub id: i64,
@@ -24,7 +24,7 @@ impl Blog {
 }
 
 #[model]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "fake", derive(Dummy))]
 pub struct Post {
     pub id: i64,
@@ -60,7 +60,7 @@ pub struct PostMetadata {
 }
 
 #[model]
-#[derive(Debug)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "fake", derive(Dummy))]
 #[table = "tags"]
 pub struct Tag {
@@ -76,8 +76,10 @@ impl Tag {
     }
 }
 
+#[allow(unused_mut, unused_variables)]
 pub fn create_tag(conn: &Connection, name: &str) -> Tag {
     let mut tag = Tag::new(name);
+    #[cfg(not(feature = "auto-save-related"))]
     tag.save(conn).unwrap();
     tag
 }

--- a/butane/tests/many.rs
+++ b/butane/tests/many.rs
@@ -8,6 +8,7 @@ mod common;
 use common::blog::{create_tag, Blog, Post, Tag};
 
 #[model]
+#[derive(Clone)]
 struct AutoPkWithMany {
     #[auto]
     id: i64,
@@ -27,6 +28,7 @@ impl AutoPkWithMany {
 
 #[model]
 #[table = "renamed_many_table"]
+#[derive(Clone)]
 struct RenamedAutoPkWithMany {
     #[auto]
     id: i64,
@@ -45,6 +47,7 @@ impl RenamedAutoPkWithMany {
 }
 
 #[model]
+#[derive(Clone)]
 struct AutoItem {
     #[auto]
     id: i64,
@@ -160,6 +163,7 @@ fn can_add_to_many_before_save(conn: Connection) {
 }
 testall!(can_add_to_many_before_save);
 
+#[cfg(not(feature = "auto-save-related"))]
 fn cant_add_unsaved_to_many(_conn: Connection) {
     let unsaved_item = AutoItem {
         id: -1,
@@ -171,6 +175,7 @@ fn cant_add_unsaved_to_many(_conn: Connection) {
         .add(&unsaved_item)
         .expect_err("unexpectedly not error");
 }
+#[cfg(not(feature = "auto-save-related"))]
 testall!(cant_add_unsaved_to_many);
 
 fn can_add_to_many_with_custom_table_name(conn: Connection) {

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Electron100/butane"
 
 
 [features]
+auto-save-related = []
 datetime = ["chrono", "postgres?/with-chrono-0_4"]
 debug = ["log"]
 fake = ["dep:fake", "rand"]

--- a/butane_test_helper/src/lib.rs
+++ b/butane_test_helper/src/lib.rs
@@ -185,6 +185,7 @@ pub fn setup_db(backend: Box<dyn Backend>, conn: &mut Connection, migrate: bool)
         println!("Applying migration {}", m.name());
         m.apply(conn).unwrap();
     }
+    println!("database setup completed");
 }
 
 pub fn sqlite_connection() -> Connection {

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -11,7 +11,7 @@ use butane::prelude::*;
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[model]
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct Blog {
     #[auto]
     id: i64,
@@ -19,7 +19,7 @@ struct Blog {
 }
 
 #[model]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Post {
     #[auto]
     id: i64,
@@ -48,7 +48,7 @@ impl Post {
 }
 
 #[model]
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct Tag {
     #[pk]
     tag: String,

--- a/examples/getting_started/src/models.rs
+++ b/examples/getting_started/src/models.rs
@@ -2,7 +2,7 @@ use butane::prelude::*;
 use butane::{model, ForeignKey, Many, ObjectState};
 
 #[model]
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Blog {
     #[auto]
     pub id: i64,
@@ -18,6 +18,7 @@ impl Blog {
 }
 
 #[model]
+#[derive(Clone, Debug)]
 pub struct Post {
     #[auto]
     pub id: i32,
@@ -47,7 +48,7 @@ impl Post {
 }
 
 #[model]
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Tag {
     #[pk]
     pub tag: String,


### PR DESCRIPTION
Attempt at solving https://github.com/Electron100/butane/issues/109
It still has lots of todo's:

- This is a very basic implementation, which will break if the schema has circular `Many` references. I'm not sure if butane can support this at the moment. (There is self-referential fkey support)  If so, this auto-save feature will need to be feature flagged.
- Cloning the items can result in lots of memory being used for large objects - I have another implementation which avoids this, but it isnt working yet
- ...