### PR TITLE
Improve checking for unitialized values added to a Many

### DIFF
--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -91,6 +91,10 @@ pub fn impl_dbobject(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
                 use butane::prelude::DataObject;
                 conn.delete(Self::TABLE, Self::PKCOL, self.pk().to_sql())
             }
+
+            fn is_saved(&self) -> butane::Result<bool> {
+                Ok(self.state.saved)
+            }
         }
         impl butane::ToSql for #tyname {
             fn to_sql(&self) -> butane::SqlVal {

--- a/butane_core/src/lib.rs
+++ b/butane_core/src/lib.rs
@@ -120,6 +120,8 @@ pub trait DataObject: DataResult<DBO = Self> {
     fn save(&mut self, conn: &impl ConnectionMethods) -> Result<()>;
     /// Delete the object from the database.
     fn delete(&self, conn: &impl ConnectionMethods) -> Result<()>;
+
+    fn is_saved(&self) -> Result<bool>;
 }
 
 pub trait ModelTyped {
@@ -171,6 +173,8 @@ pub enum Error {
     IncompatibleCustomT(custom::SqlTypeCustom, &'static str),
     #[error("Literal values for custom types are currently unsupported.")]
     LiteralForCustomUnsupported(custom::SqlValCustom),
+    #[error("This DataObject doesn't support determining whether it has been saved.")]
+    SaveDeterminationNotSupported,
     #[error("(De)serialization error {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("IO error {0}")]

--- a/butane_core/src/lib.rs
+++ b/butane_core/src/lib.rs
@@ -121,6 +121,7 @@ pub trait DataObject: DataResult<DBO = Self> {
     /// Delete the object from the database.
     fn delete(&self, conn: &impl ConnectionMethods) -> Result<()>;
 
+    /// Test if this object has been saved to the database at least once
     fn is_saved(&self) -> Result<bool>;
 }
 

--- a/butane_core/src/many.rs
+++ b/butane_core/src/many.rs
@@ -72,15 +72,11 @@ where
     /// to have an uninitialized one.
     pub fn add(&mut self, new_val: &T) -> Result<()> {
         // Check for uninitialized pk
-        if T::AUTO_PK {
-            let ipk: i64 = match new_val.pk().to_sql() {
-                SqlVal::Int(i) => i as i64,
-                SqlVal::BigInt(i) => i,
-                _ => 1,
-            };
-            if ipk < 0 {
-                return Err(Error::ValueNotSaved);
-            }
+        match new_val.is_saved() {
+            Ok(true) => (), // hooray
+            Ok(false) => return Err(Error::ValueNotSaved),
+            Err(Error::SaveDeterminationNotSupported) => (), // we don't know, so assume it's OK
+            Err(e) => return Err(e),                         // unexpected error
         }
 
         // all_values is now out of date, so clear it

--- a/butane_core/src/migrations/mod.rs
+++ b/butane_core/src/migrations/mod.rs
@@ -275,4 +275,9 @@ impl DataObject for ButaneMigration {
     fn delete(&self, conn: &impl ConnectionMethods) -> Result<()> {
         conn.delete(Self::TABLE, Self::PKCOL, self.pk().to_sql())
     }
+    fn is_saved(&self) -> Result<bool> {
+        // In practice we don't expect this to be called as
+        // ButaneMigration is not exposed outside the library
+        Err(Error::SaveDeterminationNotSupported)
+    }
 }


### PR DESCRIPTION
This is a potential partial fix for #109 in that it reduces the risk of accidentally adding to a many an object with a primay key that isn't actually recorded in the database yet.

It does not provide an ideal solution in that it merely detects, rather than automatically saving.

Posting for comparison and discussion with #113 