### PR TITLE
Add more flexibility in type path matching in proc macro

### DIFF
--- a/butane/tests/common/blog.rs
+++ b/butane/tests/common/blog.rs
@@ -31,7 +31,7 @@ pub struct Post {
     pub title: String,
     pub body: String,
     pub published: bool,
-    pub pub_time: Option<NaiveDateTime>,
+    pub pub_time: std::option::Option<NaiveDateTime>,
     pub likes: i32,
     pub tags: Many<Tag>,
     pub blog: ForeignKey<Blog>,

--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -261,7 +261,7 @@ fn fieldexpr_func_regular(f: &Field, ast_struct: &ItemStruct) -> TokenStream2 {
 
 fn fieldexpr_func_many(f: &Field, ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
     let tyname = &ast_struct.ident;
-    let fty = get_foreign_type_argument(&f.ty, "Many").expect("Many field misdetected");
+    let fty = get_foreign_type_argument(&f.ty, &MANY_TYNAMES).expect("Many field misdetected");
     let many_table_lit = many_table_lit(ast_struct, f, config);
     fieldexpr_func(
         f,


### PR DESCRIPTION
Unfortunately because we don't have the type system available at proc-macro time, when evaluating model fields we look for specific paths like `Option`, `ForeignKey` etc. This change makes it easy to check for the base name as well as fully qualified name and allows fully-qualified names for `Option`, `Many`, and `ForeignKey`. It still does not support aliased names.

Fixes #115