### PR TITLE
Deny missing_docs in some modules

### DIFF
--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -1,3 +1,10 @@
+//! An experimental ORM for Rust with a focus on simplicity and on writing Rust, not SQL
+
+//! Butane takes an object-oriented approach to database operations.
+//! It may be thought of as much as an object-persistence system as an ORM.
+//! The fact that it is backed by a SQL database is mostly an implementation detail to the API consumer.
+
+#![deny(missing_docs)]
 pub use butane_codegen::{butane_type, dataresult, model, FieldType};
 pub use butane_core::custom;
 pub use butane_core::fkey::ForeignKey;
@@ -10,6 +17,7 @@ pub use butane_core::{
 };
 
 pub mod db {
+    //! Database helpers
     pub use butane_core::db::*;
 }
 

--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -21,61 +21,6 @@ pub mod db {
     pub use butane_core::db::*;
 }
 
-/// Macro to construct a [`BoolExpr`] (for use with a [`Query`]) from
-/// an expression with Rust syntax.
-///
-/// Using this macro instead of constructing a `BoolExpr` has two
-/// advantages:
-/// 1. It will generally be more ergonomic
-/// 2. References to nonexistent fields or type mismatches
-///    (e.g. comparing a number to a string) will generate a compilation error
-///
-/// Usage: `filter!(Foo, expr)` where `Foo` is a model type (with the
-/// `#[model]` attribute applied) and `expr` is a Rust-like expression
-/// with a boolean value. `Foo`'s fields may be referred to as if they
-/// were variables.
-///
-/// # Rust values
-/// To refer to values from the surrounding rust function, enclose
-/// them in braces, like `filter!(Foo, bar == {bar})`
-///
-/// # Function-like operations
-/// Filters support some operations for which Rust does not have operators and which are instead
-/// represented syntactically as function calls.
-/// * `like`: parameter is a SQL LIKE expression string, e.g. `title.like("M%").
-/// * `matches`: Parameter is a sub-expression. Use with a
-///   [`ForeignKey`] field to evaluate as true if the referent
-///   matches. For example, to find all posts made in blogs by people
-///   named "Pete" we might say `filter!(Post, `blog.matches(author == "Pete"))`.
-/// * `contains`: Essentially the many-to-many version of `matches`.
-///    Parameter is a sub-expression. Use with a [`Many`]
-///    field to evaluate as true if one of the many referents matches
-///    the given expression. For example, in a blog post model with a field
-///    `tags: Many<Tag>` we could filter to posts with a "cats" with
-///    the following `tags.contains(tag == "cats"). If the expression
-///    is single literal, it is assumed to be used to match the
-///    primary key.
-///
-/// # Examples
-/// ```
-/// # use butane::query::BoolExpr;
-/// # use butane_codegen::model;
-/// # use butane_codegen::filter;
-/// #[model]
-/// struct Contestant {
-///   #[pk]
-///   name: String,
-///   rank: i32,
-///   nationality: String
-/// }
-/// let e: BoolExpr = filter!(Contestant, nationality == "US" && rank < 42);
-/// let first_place = 1;
-/// let e2 = filter!(Contestant, rank == { first_place });
-/// let e3 = filter!(Contestant, name.like("A%"));
-///```
-///
-/// [`BoolExpr`]: crate::query::BoolExpr
-/// [`Query`]: crate::query::Query
 pub use butane_codegen::filter;
 
 /// Constructs a filtered database query.

--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -72,7 +72,7 @@ pub mod db {
 /// let first_place = 1;
 /// let e2 = filter!(Contestant, rank == { first_place });
 /// let e3 = filter!(Contestant, name.like("A%"));
-///```
+/// ```
 ///
 /// [`BoolExpr`]: crate::query::BoolExpr
 /// [`Query`]: crate::query::Query
@@ -98,7 +98,7 @@ pub use butane_codegen::filter;
 ///   nationality: String
 /// }
 /// let top_tier: Query<Contestant> = query!(Contestant, rank <= 10);
-///```
+/// ```
 ///
 /// [`filter]: crate::filter
 /// [`Query`]: crate::query::Query
@@ -150,7 +150,7 @@ macro_rules! colname {
 ///
 /// let conn = butane::db::connect(&ConnectionSpec::new("sqlite", "foo.db")).unwrap();
 /// let alice: Result<Contestant, butane::Error> = find!(Contestant, name == "Alice", &conn);
-///```
+/// ```
 ///
 /// [`filter]: crate::filter
 /// [`Result`]: crate::Result

--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -21,6 +21,61 @@ pub mod db {
     pub use butane_core::db::*;
 }
 
+/// Macro to construct a [`BoolExpr`] (for use with a [`Query`]) from
+/// an expression with Rust syntax.
+///
+/// Using this macro instead of constructing a `BoolExpr` has two
+/// advantages:
+/// 1. It will generally be more ergonomic
+/// 2. References to nonexistent fields or type mismatches
+///    (e.g. comparing a number to a string) will generate a compilation error
+///
+/// Usage: `filter!(Foo, expr)` where `Foo` is a model type (with the
+/// `#[model]` attribute applied) and `expr` is a Rust-like expression
+/// with a boolean value. `Foo`'s fields may be referred to as if they
+/// were variables.
+///
+/// # Rust values
+/// To refer to values from the surrounding rust function, enclose
+/// them in braces, like `filter!(Foo, bar == {bar})`
+///
+/// # Function-like operations
+/// Filters support some operations for which Rust does not have operators and which are instead
+/// represented syntactically as function calls.
+/// * `like`: parameter is a SQL LIKE expression string, e.g. `title.like("M%").
+/// * `matches`: Parameter is a sub-expression. Use with a
+///   [`ForeignKey`] field to evaluate as true if the referent
+///   matches. For example, to find all posts made in blogs by people
+///   named "Pete" we might say `filter!(Post, `blog.matches(author == "Pete"))`.
+/// * `contains`: Essentially the many-to-many version of `matches`.
+///    Parameter is a sub-expression. Use with a [`Many`]
+///    field to evaluate as true if one of the many referents matches
+///    the given expression. For example, in a blog post model with a field
+///    `tags: Many<Tag>` we could filter to posts with a "cats" with
+///    the following `tags.contains(tag == "cats"). If the expression
+///    is single literal, it is assumed to be used to match the
+///    primary key.
+///
+/// # Examples
+/// ```
+/// # use butane::query::BoolExpr;
+/// # use butane_codegen::model;
+/// # use butane_codegen::filter;
+/// #[model]
+/// struct Contestant {
+///   #[pk]
+///   name: String,
+///   rank: i32,
+///   nationality: String
+/// }
+/// let e: BoolExpr = filter!(Contestant, nationality == "US" && rank < 42);
+/// let first_place = 1;
+/// let e2 = filter!(Contestant, rank == { first_place });
+/// let e3 = filter!(Contestant, name.like("A%"));
+///```
+///
+/// [`BoolExpr`]: crate::query::BoolExpr
+/// [`Query`]: crate::query::Query
 pub use butane_codegen::filter;
 
 /// Constructs a filtered database query.

--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -118,8 +118,8 @@ pub fn dataresult(args: TokenStream, input: TokenStream) -> TokenStream {
 ///    primary key.
 ///
 /// # Examples
-/// ```
-/// # use butane::query::BoolExpr;
+/// ```ignore
+/// # use butane_core::query::BoolExpr;
 /// # use butane_codegen::model;
 /// # use butane_codegen::filter;
 /// #[model]
@@ -135,8 +135,8 @@ pub fn dataresult(args: TokenStream, input: TokenStream) -> TokenStream {
 /// let e3 = filter!(Contestant, name.like("A%"));
 ///```
 ///
-/// [`BoolExpr`]: crate::query::BoolExpr
-/// [`Query`]: crate::query::Query
+/// [`BoolExpr`]: butane_core::query::BoolExpr
+/// [`Query`]: butane_core::query::Query
 #[proc_macro]
 pub fn filter(input: TokenStream) -> TokenStream {
     let input: TokenStream2 = input.into();

--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -1,6 +1,8 @@
+//! Macros for butane
+
 //The quote macro can require a high recursion limit
 #![recursion_limit = "256"]
-
+#![deny(missing_docs)]
 extern crate proc_macro;
 
 use butane_core::migrations::adb::{DeferredSqlType, TypeIdentifier};
@@ -80,6 +82,61 @@ pub fn dataresult(args: TokenStream, input: TokenStream) -> TokenStream {
     codegen::dataresult(args.into(), input.into()).into()
 }
 
+/// Macro to construct a [`BoolExpr`] (for use with a [`Query`]) from
+/// an expression with Rust syntax.
+///
+/// Using this macro instead of constructing a `BoolExpr` has two
+/// advantages:
+/// 1. It will generally be more ergonomic
+/// 2. References to nonexistent fields or type mismatches
+///    (e.g. comparing a number to a string) will generate a compilation error
+///
+/// Usage: `filter!(Foo, expr)` where `Foo` is a model type (with the
+/// `#[model]` attribute applied) and `expr` is a Rust-like expression
+/// with a boolean value. `Foo`'s fields may be referred to as if they
+/// were variables.
+///
+/// # Rust values
+/// To refer to values from the surrounding rust function, enclose
+/// them in braces, like `filter!(Foo, bar == {bar})`
+///
+/// # Function-like operations
+/// Filters support some operations for which Rust does not have operators and which are instead
+/// represented syntactically as function calls.
+/// * `like`: parameter is a SQL LIKE expression string, e.g. `title.like("M%").
+/// * `matches`: Parameter is a sub-expression. Use with a
+///   [`ForeignKey`] field to evaluate as true if the referent
+///   matches. For example, to find all posts made in blogs by people
+///   named "Pete" we might say `filter!(Post, `blog.matches(author == "Pete"))`.
+/// * `contains`: Essentially the many-to-many version of `matches`.
+///    Parameter is a sub-expression. Use with a [`Many`]
+///    field to evaluate as true if one of the many referents matches
+///    the given expression. For example, in a blog post model with a field
+///    `tags: Many<Tag>` we could filter to posts with a "cats" with
+///    the following `tags.contains(tag == "cats"). If the expression
+///    is single literal, it is assumed to be used to match the
+///    primary key.
+///
+/// # Examples
+/// ```
+/// # use butane::query::BoolExpr;
+/// # use butane_codegen::model;
+/// # use butane_codegen::filter;
+/// #[model]
+/// struct Contestant {
+///   #[pk]
+///   name: String,
+///   rank: i32,
+///   nationality: String
+/// }
+/// let e: BoolExpr = filter!(Contestant, nationality == "US" && rank < 42);
+/// let first_place = 1;
+/// let e2 = filter!(Contestant, rank == { first_place });
+/// let e3 = filter!(Contestant, name.like("A%"));
+///```
+///
+/// [`BoolExpr`]: crate::query::BoolExpr
+/// [`Query`]: crate::query::Query
 #[proc_macro]
 pub fn filter(input: TokenStream) -> TokenStream {
     let input: TokenStream2 = input.into();
@@ -169,6 +226,17 @@ fn migrations_dir() -> PathBuf {
     dir
 }
 
+/// Derive macro for `FieldType`.
+/// Produces a String field for simple enums, otherwise uses a JSON field if json feature is enabled.
+/// E.g.
+/// ```ignore
+/// #[derive(FieldType)]
+/// pub enum Currency {
+///   Dollars,
+///   Pounds,
+///   Euros,
+/// }
+/// ```
 #[proc_macro_derive(FieldType)]
 pub fn derive_field_type(input: TokenStream) -> TokenStream {
     let derive_input = syn::parse_macro_input!(input as syn::DeriveInput);

--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -133,9 +133,11 @@ pub fn dataresult(args: TokenStream, input: TokenStream) -> TokenStream {
 /// let first_place = 1;
 /// let e2 = filter!(Contestant, rank == { first_place });
 /// let e3 = filter!(Contestant, name.like("A%"));
-///```
+/// ```
 ///
 /// [`BoolExpr`]: butane_core::query::BoolExpr
+/// [`ForeignKey`]: butane_core::fkey::ForeignKey
+/// [`Many`]: butane_core::many::Many
 /// [`Query`]: butane_core::query::Query
 #[proc_macro]
 pub fn filter(input: TokenStream) -> TokenStream {

--- a/butane_core/src/codegen/mod.rs
+++ b/butane_core/src/codegen/mod.rs
@@ -1,3 +1,5 @@
+//! Code-generation backend
+
 use crate::migrations::adb::{DeferredSqlType, TypeIdentifier, TypeKey};
 use crate::migrations::{MigrationMut, MigrationsMut};
 use crate::{SqlType, SqlVal};

--- a/butane_core/src/fkey.rs
+++ b/butane_core/src/fkey.rs
@@ -1,3 +1,5 @@
+//! Implementation of foreign key relationships between models.
+#![deny(missing_docs)]
 use crate::db::ConnectionMethods;
 use crate::*;
 use once_cell::unsync::OnceCell;
@@ -33,6 +35,7 @@ where
     valpk: OnceCell<SqlVal>,
 }
 impl<T: DataObject> ForeignKey<T> {
+    /// Create a value from a reference to the primary key of the value
     pub fn from_pk(pk: T::PKType) -> Self {
         let ret = Self::new_raw();
         ret.valpk.set(pk.into_sql()).unwrap();

--- a/butane_core/src/many.rs
+++ b/butane_core/src/many.rs
@@ -1,3 +1,5 @@
+//! Implementation of many-to-many relationships between models.
+#![deny(missing_docs)]
 use crate::db::{Column, ConnectionMethods};
 use crate::query::{BoolExpr, Expr};
 use crate::{DataObject, Error, FieldType, Result, SqlType, SqlVal, ToSql};
@@ -123,7 +125,7 @@ where
         Ok(())
     }
 
-    /// Loads the values referred to by this foreign key from the
+    /// Loads the values referred to by this many relationship from the
     /// database if necessary and returns a reference to them.
     pub fn load(&self, conn: &impl ConnectionMethods) -> Result<impl Iterator<Item = &T>> {
         let vals: Result<&Vec<T>> = self.all_values.get_or_try_init(|| {
@@ -153,6 +155,7 @@ where
         vals.map(|v| v.iter())
     }
 
+    /// Describes the columns of the Many table
     pub fn columns(&self) -> [Column; 2] {
         [
             Column::new("owner", self.owner_type.clone()),

--- a/butane_core/src/sqlval.rs
+++ b/butane_core/src/sqlval.rs
@@ -1,3 +1,5 @@
+//! Types and traits for interacting with a value that can be stored in the database.
+
 use crate::custom::{SqlValCustom, SqlValRefCustom};
 use crate::{DataObject, Error::CannotConvertSqlVal, Result, SqlType};
 use serde::{Deserialize, Serialize};

--- a/butane_core/src/uuid.rs
+++ b/butane_core/src/uuid.rs
@@ -1,3 +1,6 @@
+//! Uuid support
+
+#![deny(missing_docs)]
 use crate::{
     Error::CannotConvertSqlVal, FieldType, FromSql, PrimaryKeyType, Result, SqlType, SqlVal,
     SqlValRef, ToSql,


### PR DESCRIPTION
The objective would be to keep adding docs where they are missing, adding more `deny` to prevent regressions, and move these `deny` up higher until there is only one left in each package.