### PR TITLE
WIP: Fake relationship members

### DIFF
--- a/butane/tests/fake.rs
+++ b/butane/tests/fake.rs
@@ -1,15 +1,13 @@
 use butane::db::Connection;
-use butane::{find, DataObject, ForeignKey};
-
+use butane::{find, model, DataObject, ForeignKey, Many};
 use butane_test_helper::*;
 
+use fake::{Dummy, Fake, Faker};
+
 mod common;
+use common::blog::{Blog, Post, Tag};
 
 fn fake_blog_post(conn: Connection) {
-    use fake::{Fake, Faker};
-
-    use common::blog::{Blog, Post, Tag};
-
     let mut fake_blog: Blog = Faker.fake();
     fake_blog.save(&conn).unwrap();
 
@@ -33,3 +31,69 @@ fn fake_blog_post(conn: Connection) {
     assert_eq!(post_from_db.tags.load(&conn).unwrap().count(), 3);
 }
 testall!(fake_blog_post);
+
+// We dont want the main struct's to have `Clone`, lest
+// that becomes necessary without being noticed.
+#[model]
+#[derive(Clone, Debug, Dummy)]
+struct ClonableBlog {
+    pub id: i64,
+    pub name: String,
+}
+
+#[model]
+#[derive(Clone, Debug, Dummy)]
+struct ClonablePost {
+    pub id: i64,
+    pub title: String,
+    pub tags: Many<ClonableTag>,
+    pub blog: ForeignKey<ClonableBlog>,
+}
+
+#[model]
+#[table = "tags"]
+#[derive(Clone, Debug, Dummy)]
+pub struct ClonableTag {
+    #[pk]
+    pub tag: String,
+}
+
+/// Fake ForeignKey values can be accessed, but will not be saved
+/// resulting in inability to load them from the database.
+fn fake_auto_relationship_values(conn: Connection) {
+    let mut post: ClonablePost = Faker.fake();
+
+    // The ForeignKey value can be accessed before being saved
+    assert!(post.blog.get().is_ok());
+    // The Many has a value in it
+    assert_eq!(post.tags.get().unwrap().count(), 1);
+
+    let mut blog: ClonableBlog = post.blog.get().unwrap().clone();
+    blog.save(&conn).unwrap();
+    let blog_name = post.blog.get().unwrap().name.clone();
+    assert!(post.blog.load(&conn).is_ok());
+    assert_eq!(post.blog.load(&conn).unwrap().name, blog_name);
+
+    assert_ne!(post.blog.pk(), 0);
+
+    let mut tag: ClonableTag = post.tags.get().unwrap().next().unwrap().clone();
+    eprintln!("tag: {:?}", tag);
+    tag.save(&conn).unwrap();
+
+    let tag_from_db = find!(ClonableTag, tag == { tag.tag }, &conn).unwrap();
+    assert_eq!(tag_from_db.tag, tag_from_db.tag);
+
+    // With the Blog & Tag saved, we can save the Post,
+    // however the Many<Tag> wont be saved because they are in `all_values`.
+    post.save(&conn).unwrap();
+
+    let post_from_db = find!(ClonablePost, id == { post.id }, &conn).unwrap();
+    assert_eq!(post_from_db.title, post.title);
+
+    assert!(post_from_db.blog.load(&conn).is_ok());
+    assert_eq!(post_from_db.blog.load(&conn).unwrap().name, blog_name);
+
+    // The Many<T> were not saved
+    assert_eq!(post_from_db.tags.load(&conn).unwrap().count(), 0);
+}
+testall!(fake_auto_relationship_values);

--- a/butane_core/src/many.rs
+++ b/butane_core/src/many.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
 #[cfg(feature = "fake")]
-use fake::{Dummy, Faker};
+use fake::{Dummy, Fake, Faker};
 
 fn default_oc<T>() -> OnceCell<Vec<T>> {
     OnceCell::default()
@@ -215,9 +215,15 @@ impl<T: DataObject> Default for Many<T> {
 }
 
 #[cfg(feature = "fake")]
-/// Fake data support is currently limited to empty Many relationships.
-impl<T: DataObject> Dummy<Faker> for Many<T> {
+/// Fake data support generates one value,
+/// however it is impossible to the many relationship to it.
+/// If we put them in `new_values`, we can only store the `.pk()`
+/// which makes it impossible to save the value being related to.
+impl<T: DataObject + Dummy<Faker>> Dummy<Faker> for Many<T> {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Faker, _rng: &mut R) -> Self {
-        Self::new()
+        let obj = Faker.fake::<T>();
+        let ret = Self::new();
+        ret.all_values.set(vec![obj]).ok();
+        ret
     }
 }


### PR DESCRIPTION
This is a demo of 
- adding a fake value into a `ForeignKey<T>` looks doable, but requires `T: Clone` in order for the fake `T` to be stored in the db
- why adding fake values into a `Many<T>` looks to be incompatible with how `Many` is designed

I think it is worthwhile to generate a fake value for `ForeignKey<T>` , if only because faking with `Self::new_raw()` is really bad, because it exposes an invalid state that can not otherwise easily be reached.