### PR TITLE
Lint docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,38 @@
+CARGO := rustup run stable cargo
+CARGO_NIGHTLY := $(subst stable, nightly, $(CARGO))
 
 all : build
 
 build :
-	cargo check
+	$(CARGO) check
 	# build some intermediate configuration to test different feature combinations
-	cd butane && cargo check --features pg
-	cd butane && cargo check --features pg,datetime
-	cd butane && cargo check --features sqlite
+	cd butane && $(CARGO) check --features pg
+	cd butane && $(CARGO) check --features pg,datetime
+	cd butane && $(CARGO) check --features sqlite
 	cargo build --all-features
 
 lint :
-	cargo clippy --all-features -- -D warnings
+	$(CARGO) clippy --all-features -- -D warnings
 
 
-check : build test doc lint
+check : build test doclint lint
 
 
 test :
-	cargo test --all-features
+	$(CARGO) test --all-features
 
 clean :
-	cargo clean
+	$(CARGO) clean
+
+
+doclint :
+	RUSTDOCFLAGS="" $(CARGO_NIGHTLY) doc --no-deps --all-features
 
 doc :
-	cd butane && cargo +nightly doc --all-features
+	cd butane && $(CARGO_NIGHTLY) doc --no-deps --all-features
 
 docview :
-	cd butane && cargo +nightly doc --all-features --open
+	cd butane && $(CARGO_NIGHTLY) doc --all-features --open
 
 install :
-	cd butane_cli && cargo install --path .
+	cd butane_cli && $(CARGO) install --path .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CARGO := rustup run stable cargo
-CARGO_NIGHTLY := $(subst stable, nightly, $(CARGO))
+CARGO := cargo +stable
+CARGO_NIGHTLY := $(subst stable,nightly,$(CARGO))
 
 all : build
 
@@ -26,7 +26,7 @@ clean :
 
 
 doclint :
-	RUSTDOCFLAGS="" $(CARGO_NIGHTLY) doc --no-deps --all-features
+	RUSTDOCFLAGS="-D warnings" $(CARGO_NIGHTLY) doc --no-deps --all-features
 
 doc :
 	cd butane && $(CARGO_NIGHTLY) doc --no-deps --all-features

--- a/butane_core/src/db/mod.rs
+++ b/butane_core/src/db/mod.rs
@@ -88,8 +88,8 @@ impl BackendConnection for Connection {
 connection_method_wrapper!(Connection);
 
 /// Connection specification. Contains the name of a database backend
-/// and the backend-specific connection string. See [connect][crate::db::connect]
-/// to make a [Connection][crate::db::Connection] from a `ConnectionSpec`.
+/// and the backend-specific connection string. See [`connect`]
+/// to make a [`Connection`] from a `ConnectionSpec`.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConnectionSpec {
     pub backend_name: String,
@@ -130,7 +130,7 @@ fn conn_complete_if_dir(path: &Path) -> Cow<Path> {
     }
 }
 
-/// Database backend. A boxed implementation can be returned by name via [get_backend][crate::db::get_backend].
+/// Database backend. A boxed implementation can be returned by name via [`get_backend`].
 pub trait Backend {
     fn name(&self) -> &'static str;
     fn create_migration_sql(&self, current: &adb::ADB, ops: Vec<adb::Operation>) -> Result<String>;
@@ -161,7 +161,7 @@ pub fn get_backend(name: &str) -> Option<Box<dyn Backend>> {
 }
 
 /// Connect to a database. For non-boxed connections, see individual
-/// [Backend][crate::db::Backend] implementations.
+/// [`Backend`] implementations.
 pub fn connect(spec: &ConnectionSpec) -> Result<Connection> {
     get_backend(&spec.backend_name)
         .ok_or_else(|| Error::UnknownBackend(spec.backend_name.clone()))?

--- a/butane_core/src/db/pg.rs
+++ b/butane_core/src/db/pg.rs
@@ -17,7 +17,7 @@ use std::fmt::Write;
 /// The name of the postgres backend.
 pub const BACKEND_NAME: &str = "pg";
 
-/// Pg [Backend][crate::db::Backend] implementation.
+/// Postgres [`Backend`] implementation.
 #[derive(Debug, Default)]
 pub struct PgBackend {}
 impl PgBackend {

--- a/butane_core/src/db/sqlite.rs
+++ b/butane_core/src/db/sqlite.rs
@@ -42,7 +42,7 @@ fn log_callback(error_code: std::ffi::c_int, message: &str) {
     }
 }
 
-/// SQLite [Backend][crate::db::Backend] implementation.
+/// SQLite [`Backend`] implementation.
 #[derive(Debug, Default)]
 pub struct SQLiteBackend {}
 impl SQLiteBackend {

--- a/butane_core/src/lib.rs
+++ b/butane_core/src/lib.rs
@@ -219,7 +219,7 @@ impl From<rusqlite::types::FromSqlError> for Error {
 
 /// Enumeration of the types a database value may take.
 ///
-/// See also [`SqlVal`][crate::SqlVal].
+/// See also [`SqlVal`].
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum SqlType {
     Bool,

--- a/butane_core/src/migrations/adb.rs
+++ b/butane_core/src/migrations/adb.rs
@@ -8,8 +8,8 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
 /// Identifier for a type as used in a database column. Supports both
-/// [SqlType](crate::SqlType) and identifiers known only by name. The
-/// latter is used for custom types. `SqlType::Custom` cannot easily be used
+/// [`SqlType`] and identifiers known only by name.
+/// The latter is used for custom types. `SqlType::Custom` cannot easily be used
 /// directly at compile time when the proc macro serializing type information runs.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum TypeIdentifier {


### PR DESCRIPTION
This fixes all the warnings like

```
error: redundant explicit link target
   --> butane_core/src/lib.rs:222:25
    |
222 | /// See also [`SqlVal`][crate::SqlVal].
    |               --------  ^^^^^^^^^^^^^ explicit target is redundant
    |               |
    |               because label contains path that resolves to same destination
    |
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
222 | /// See also [`SqlVal`].
```