### PR TITLE
Add an unreachable!() in resolve_types()

### DIFF
--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::migrations::adb::{DeferredSqlType, TypeIdentifier};
+use crate::migrations::adb::{DeferredSqlType, TypeIdentifier, MANY_SUFFIX};
 use crate::SqlType;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2::{Ident, Span};
@@ -379,7 +379,7 @@ fn many_table_lit(ast_struct: &ItemStruct, field: &Field, config: &Config) -> Li
         Some(s) => s,
         None => &binding,
     };
-    make_lit(&format!("{}_{}_Many", &tyname, &ident))
+    make_lit(&format!("{}_{}{MANY_SUFFIX}", &tyname, &ident))
 }
 
 fn verify_fields(ast_struct: &ItemStruct) -> Option<TokenStream2> {

--- a/butane_core/src/codegen/migration.rs
+++ b/butane_core/src/codegen/migration.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::migrations::adb::{AColumn, ATable};
+use crate::migrations::adb::{AColumn, ATable, MANY_SUFFIX};
 use crate::migrations::{MigrationMut, MigrationsMut};
 use crate::Result;
 use syn::{Field, ItemStruct};
@@ -67,7 +67,7 @@ fn many_table(main_table_name: &str, many_field: &Field, pk_field: &Field) -> AT
         .clone()
         .expect("fields must be named")
         .to_string();
-    let mut table = ATable::new(format!("{main_table_name}_{field_name}_Many"));
+    let mut table = ATable::new(format!("{main_table_name}_{field_name}{MANY_SUFFIX}"));
     let col = AColumn::new_simple("owner", get_deferred_sql_type(&pk_field.ty));
     table.add_column(col);
     let col = AColumn::new_simple(

--- a/butane_core/src/codegen/mod.rs
+++ b/butane_core/src/codegen/mod.rs
@@ -379,7 +379,7 @@ fn get_foreign_sql_type(ty: &syn::Type, tynames: &[&'static str]) -> Option<Defe
 
 /// Determine whether a type refers to a data type that is supported directly by butane,
 /// or is a custom defined struct.
-/// It looks inside an [Option] or [butane_core::ForeignKey] to determine the inner type.
+/// It looks inside an [Option] or [crate::fkey::ForeignKey] to determine the inner type.
 pub fn get_deferred_sql_type(ty: &syn::Type) -> DeferredSqlType {
     get_primitive_sql_type(ty)
         .or_else(|| get_option_sql_type(ty))

--- a/butane_core/src/migrations/adb.rs
+++ b/butane_core/src/migrations/adb.rs
@@ -7,6 +7,9 @@ use serde::{de::Deserializer, de::Visitor, ser::Serializer, Deserialize, Seriali
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
+/// Suffix added to [`crate::many::Many`] tables.
+pub const MANY_SUFFIX: &str = "_Many";
+
 /// Identifier for a type as used in a database column. Supports both
 /// [`SqlType`] and identifiers known only by name.
 /// The latter is used for custom types. `SqlType::Custom` cannot easily be used
@@ -184,7 +187,10 @@ impl ADB {
                     if let Ok(pktype) = pktype {
                         changed |= resolver.insert_pk(&table.name, pktype.clone());
                     }
+                } else if !table.name.ends_with(MANY_SUFFIX) {
+                    unreachable!();
                 }
+
                 for col in &mut table.columns {
                     changed |= col.resolve_type(&resolver);
                 }

--- a/butane_core/src/query/fieldexpr.rs
+++ b/butane_core/src/query/fieldexpr.rs
@@ -118,7 +118,6 @@ where
         }
     }
     pub fn contains(&self, q: BoolExpr) -> BoolExpr {
-        //let many_tbl = format!("{}_{}_Many", O::TABLE, self.name);
         BoolExpr::SubqueryJoin {
             col: O::PKCOL,
             tbl2: Cow::Borrowed(T::TABLE),


### PR DESCRIPTION
Added to clarify when there is no `table.pk()`