### PR TITLE
Add migration unit tests

### DIFF
--- a/butane_core/src/migrations/adb.rs
+++ b/butane_core/src/migrations/adb.rs
@@ -393,6 +393,22 @@ impl AColumn {
     }
 }
 
+/// Create a table for the [crate::many::Many] relationship.
+/// Should not be used directly, except in tests.
+pub fn create_many_table(
+    main_table_name: &str,
+    many_field_name: &str,
+    many_field_type: DeferredSqlType,
+    main_table_pk_field_type: DeferredSqlType,
+) -> ATable {
+    let mut table = ATable::new(format!("{main_table_name}_{many_field_name}{MANY_SUFFIX}"));
+    let col = AColumn::new_simple("owner", main_table_pk_field_type);
+    table.add_column(col);
+    let col = AColumn::new_simple("has", many_field_type);
+    table.add_column(col);
+    table
+}
+
 /// Individual operation use to apply a migration.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum Operation {

--- a/butane_core/tests/migration.rs
+++ b/butane_core/tests/migration.rs
@@ -137,3 +137,275 @@ fn stable_add_column_alpha_order() {
         ]
     );
 }
+
+#[test]
+fn add_table_fkey() {
+    let known_int_type = DeferredSqlType::KnownId(TypeIdentifier::Ty(SqlType::Int));
+
+    let old = ADB::default();
+    let mut new = ADB::default();
+    let mut table_a = ATable::new("a".to_owned());
+    let column = AColumn::new(
+        "id".to_owned(),
+        known_int_type.clone(),
+        false, // nullable
+        true,  // pk
+        false, // auto
+        false, // unique
+        None,  // default
+    );
+    table_a.add_column(column);
+    new.replace_table(table_a.clone());
+
+    let mut table_b = ATable::new("b".to_owned());
+    let column = AColumn::new(
+        "b".to_owned(),
+        DeferredSqlType::Deferred(TypeKey::PK("a".to_owned())),
+        false, // nullable
+        true,  // pk
+        false, // auto
+        false, // unique
+        None,  // default
+    );
+    table_b.add_column(column);
+    new.replace_table(table_b.clone());
+
+    new.resolve_types().unwrap();
+
+    let mut resolved_table_b = ATable::new("b".to_owned());
+    let column = AColumn::new(
+        "b".to_owned(),
+        known_int_type.clone(),
+        false, // nullable
+        true,  // pk
+        false, // auto
+        false, // unique
+        None,  // default
+    );
+    resolved_table_b.add_column(column);
+
+    let ops = diff(&old, &new);
+
+    assert_eq!(
+        ops,
+        vec![
+            Operation::AddTable(table_a),
+            Operation::AddTable(resolved_table_b.clone()),
+        ]
+    );
+}
+
+fn create_add_renamed_table_fkey_ops() -> (Vec<Operation>, ADB, ATable, ATable) {
+    let known_int_type = DeferredSqlType::KnownId(TypeIdentifier::Ty(SqlType::Int));
+
+    let old = ADB::default();
+    let mut new = ADB::default();
+    let mut table_a = ATable::new("a_table".to_owned());
+    let column = AColumn::new(
+        "id".to_owned(),
+        known_int_type.clone(),
+        false, // nullable
+        true,  // pk
+        false, // auto
+        false, // unique
+        None,  // default
+    );
+    table_a.add_column(column);
+    new.replace_table(table_a.clone());
+
+    // Add the type "a" renamed to table "a_table"
+    let type_name = TypeKey::PK("a".to_owned());
+    let table_name = DeferredSqlType::Deferred(TypeKey::PK("a_table".to_owned()));
+    new.add_type(type_name, table_name);
+
+    let mut table_b = ATable::new("b".to_owned());
+    let column = AColumn::new(
+        "b".to_owned(),
+        DeferredSqlType::Deferred(TypeKey::PK("a".to_owned())),
+        false, // nullable
+        true,  // pk
+        false, // auto
+        false, // unique
+        None,  // default
+    );
+    table_b.add_column(column);
+    new.replace_table(table_b.clone());
+
+    new.resolve_types().unwrap();
+
+    let mut resolved_table_b = ATable::new("b".to_owned());
+    let column = AColumn::new(
+        "b".to_owned(),
+        known_int_type.clone(),
+        false, // nullable
+        true,  // pk
+        false, // auto
+        false, // unique
+        None,  // default
+    );
+    resolved_table_b.add_column(column);
+
+    let ops = diff(&old, &new);
+
+    (ops, new, table_a, resolved_table_b)
+}
+
+#[test]
+fn add_renamed_table_fkey() {
+    let (ops, _, table_a, resolved_table_b) = create_add_renamed_table_fkey_ops();
+
+    assert_eq!(
+        ops,
+        vec![
+            Operation::AddTable(table_a),
+            Operation::AddTable(resolved_table_b.clone()),
+        ]
+    );
+}
+
+#[test]
+fn add_renamed_table_fkey_ddl_sqlite() {
+    let (ops, new, ..) = create_add_renamed_table_fkey_ops();
+
+    let backend = butane_core::db::get_backend("sqlite").unwrap();
+    let sql = backend.create_migration_sql(&new, ops).unwrap();
+    let sql_lines: Vec<&str> = sql.lines().collect();
+    assert_eq!(
+        sql_lines,
+        vec![
+            "CREATE TABLE a_table (",
+            "id INTEGER NOT NULL PRIMARY KEY",
+            ");",
+            "CREATE TABLE b (",
+            "b INTEGER NOT NULL PRIMARY KEY",
+            ");",
+        ]
+    );
+}
+
+#[test]
+fn add_renamed_table_fkey_ddl_pg() {
+    let (ops, new, ..) = create_add_renamed_table_fkey_ops();
+
+    let backend = butane_core::db::get_backend("pg").unwrap();
+    let sql = backend.create_migration_sql(&new, ops).unwrap();
+    let sql_lines: Vec<&str> = sql.lines().collect();
+    assert_eq!(
+        sql_lines,
+        vec![
+            "CREATE TABLE a_table (",
+            "id INTEGER NOT NULL PRIMARY KEY",
+            ");",
+            "CREATE TABLE b (",
+            "b INTEGER NOT NULL PRIMARY KEY",
+            ");",
+        ]
+    );
+}
+
+fn create_add_table_many_ops() -> (Vec<Operation>, ADB, ATable, ATable, ATable) {
+    let known_int_type = DeferredSqlType::KnownId(TypeIdentifier::Ty(SqlType::Int));
+
+    let old = ADB::default();
+    let mut new = ADB::default();
+
+    let id_column = AColumn::new(
+        "id".to_owned(),
+        known_int_type.clone(),
+        false, // nullable
+        true,  // pk
+        false, // auto
+        false, // unique
+        None,  // default
+    );
+
+    let mut table_a = ATable::new("a".to_owned());
+    table_a.add_column(id_column.clone());
+    new.replace_table(table_a.clone());
+
+    let mut table_b = ATable::new("b".to_owned());
+    table_b.add_column(id_column);
+
+    new.replace_table(table_b.clone());
+
+    let many_table = butane_core::migrations::adb::create_many_table(
+        "b",
+        "many_a",
+        DeferredSqlType::Deferred(TypeKey::PK("a".to_owned())),
+        known_int_type.clone(),
+    );
+    new.replace_table(many_table.clone());
+
+    new.resolve_types().unwrap();
+
+    let mut resolved_many_table = ATable::new(many_table.name);
+    let resolved_owner_column = AColumn::new_simple("owner", known_int_type.clone());
+    let resolved_has_column = AColumn::new_simple("has", known_int_type.clone());
+    resolved_many_table.add_column(resolved_owner_column);
+    resolved_many_table.add_column(resolved_has_column);
+
+    let ops = diff(&old, &new);
+    (ops, new, table_a, table_b, resolved_many_table)
+}
+
+#[test]
+fn add_table_many() {
+    let (ops, _, table_a, table_b, resolved_many_table) = create_add_table_many_ops();
+
+    assert_eq!(
+        ops,
+        vec![
+            Operation::AddTable(table_a),
+            Operation::AddTable(table_b.clone()),
+            Operation::AddTable(resolved_many_table.clone()),
+        ]
+    );
+}
+
+#[test]
+fn add_table_many_ddl_sqlite() {
+    let (ops, new, ..) = create_add_table_many_ops();
+
+    let backend = butane_core::db::get_backend("sqlite").unwrap();
+    let sql = backend.create_migration_sql(&new, ops).unwrap();
+    let sql_lines: Vec<&str> = sql.lines().collect();
+    assert_eq!(
+        sql_lines,
+        vec![
+            "CREATE TABLE a (",
+            "id INTEGER NOT NULL PRIMARY KEY",
+            ");",
+            "CREATE TABLE b (",
+            "id INTEGER NOT NULL PRIMARY KEY",
+            ");",
+            "CREATE TABLE b_many_a_Many (",
+            "owner INTEGER NOT NULL,",
+            "has INTEGER NOT NULL",
+            ");",
+        ]
+    );
+}
+
+#[test]
+fn add_table_many_ddl_pg() {
+    let (ops, new, ..) = create_add_table_many_ops();
+
+    let backend = butane_core::db::get_backend("pg").unwrap();
+    let sql = backend.create_migration_sql(&new, ops).unwrap();
+    let sql_lines: Vec<&str> = sql.lines().collect();
+    assert_eq!(
+        sql_lines,
+        vec![
+            "CREATE TABLE a (",
+            "id INTEGER NOT NULL PRIMARY KEY",
+            ");",
+            "CREATE TABLE b (",
+            "id INTEGER NOT NULL PRIMARY KEY",
+            ");",
+            "CREATE TABLE b_many_a_Many (",
+            "owner INTEGER NOT NULL,",
+            "has INTEGER NOT NULL",
+            ");",
+        ]
+    );
+}

--- a/butane_core/tests/migration.rs
+++ b/butane_core/tests/migration.rs
@@ -195,6 +195,8 @@ fn add_table_fkey() {
     );
 }
 
+/// Creates the test case for adding a foreign key, returning the migration operations,
+/// the target ADB, and the tables which should be expected to be created.
 fn create_add_renamed_table_fkey_ops() -> (Vec<Operation>, ADB, ATable, ATable) {
     let known_int_type = DeferredSqlType::KnownId(TypeIdentifier::Ty(SqlType::Int));
 
@@ -303,6 +305,8 @@ fn add_renamed_table_fkey_ddl_pg() {
     );
 }
 
+/// Creates the test case for adding a many table, returning the migration operations,
+/// the target ADB, and the tables which should be expected to be created.
 fn create_add_table_many_ops() -> (Vec<Operation>, ADB, ATable, ATable, ATable) {
     let known_int_type = DeferredSqlType::KnownId(TypeIdentifier::Ty(SqlType::Int));
 


### PR DESCRIPTION
Creates a pub "create_many_table" so that it is easier to build unit test cases outside of `src/` . Happy to move the tests into test submodules if you prefer that.