### PR TITLE
Fix clippy empty_structs_with_brackets

### DIFF
--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -247,6 +247,7 @@ fn make_tablelit(config: &Config, tyname: &Ident) -> LitStr {
     }
 }
 
+/// Help to generate field expressions for each `#[butane::model]`.
 pub fn add_fieldexprs(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
     let tyname = &ast_struct.ident;
     let vis = &ast_struct.vis;

--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -269,8 +269,7 @@ pub fn add_fieldexprs(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 
             }
         }
         /// Helper struct for butane model.
-        #vis struct #fields_type {
-        }
+        #vis struct #fields_type;
         impl #fields_type {
             #(#fieldexprs)*
         }

--- a/butane_core/src/db/pg.rs
+++ b/butane_core/src/db/pg.rs
@@ -25,7 +25,7 @@ pub const BACKEND_NAME: &str = "pg";
 
 /// Postgres [`Backend`] implementation.
 #[derive(Debug, Default)]
-pub struct PgBackend {}
+pub struct PgBackend;
 impl PgBackend {
     pub fn new() -> PgBackend {
         PgBackend {}

--- a/butane_core/src/db/sqlite.rs
+++ b/butane_core/src/db/sqlite.rs
@@ -50,7 +50,7 @@ fn log_callback(error_code: std::ffi::c_int, message: &str) {
 
 /// SQLite [`Backend`] implementation.
 #[derive(Debug, Default)]
-pub struct SQLiteBackend {}
+pub struct SQLiteBackend;
 impl SQLiteBackend {
     pub fn new() -> SQLiteBackend {
         SQLiteBackend {}
@@ -728,7 +728,7 @@ pub fn sql_insert_or_update(table: &str, columns: &[Column], pkcol: &Column, w: 
 }
 
 #[derive(Debug)]
-struct SQLitePlaceholderSource {}
+struct SQLitePlaceholderSource;
 impl SQLitePlaceholderSource {
     fn new() -> Self {
         SQLitePlaceholderSource {}

--- a/butane_core/src/migrations/fs.rs
+++ b/butane_core/src/migrations/fs.rs
@@ -18,7 +18,7 @@ pub trait Filesystem: Debug {
 }
 
 #[derive(Debug)]
-pub struct OsFilesystem {}
+pub struct OsFilesystem;
 
 impl Filesystem for OsFilesystem {
     fn ensure_dir(&self, path: &Path) -> std::io::Result<()> {

--- a/butane_core/src/migrations/fs.rs
+++ b/butane_core/src/migrations/fs.rs
@@ -17,6 +17,7 @@ pub trait Filesystem: Debug {
     fn read(&self, path: &Path) -> std::io::Result<Box<dyn Read>>;
 }
 
+/// `[Filesystem`] implementation using [`std::fs`].
 #[derive(Debug)]
 pub struct OsFilesystem;
 


### PR DESCRIPTION
Fixes https://rust-lang.github.io/rust-clippy/master/index.html#/empty_structs_with_brackets in generated code & in butane code.