### PR TITLE
Move save logic out of procmacro

### DIFF
--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -9,6 +9,7 @@
 pub use butane_codegen::{butane_type, dataresult, model, FieldType};
 pub use butane_core::custom;
 pub use butane_core::fkey::ForeignKey;
+pub use butane_core::internal;
 pub use butane_core::many::Many;
 pub use butane_core::migrations;
 pub use butane_core::query;

--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -34,53 +34,8 @@ pub fn impl_dbobject(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
     let auto_pk = is_auto(&pk_field);
 
     let values: Vec<TokenStream2> = push_values(ast_struct, |_| true);
+    let values_no_pk: Vec<TokenStream2> = push_values(ast_struct, |f: &Field| f != &pk_field);
     let insert_cols = columns(ast_struct, |f| !is_auto(f));
-
-    let save_core = if auto_pk && values.len() == 1 {
-        quote!(
-            if !butane::PrimaryKeyType::is_valid(self.pk()) {
-                let pk = conn.insert_returning_pk(Self::TABLE, &[], &pkcol, &[])?;
-                Some(butane::FromSql::from_sql(pk)?)
-            } else {
-                None
-            };
-        )
-    } else if auto_pk {
-        let values_no_pk: Vec<TokenStream2> = push_values(ast_struct, |f: &Field| f != &pk_field);
-        let save_cols = columns(ast_struct, |f| !is_auto(f) && f != &pk_field);
-        quote!(
-            // Since we expect our pk field to be invalid and to be created by the insert,
-            // we do a pure insert or update based on whether the AutoPk is already valid or not.
-            // Note that some database backends do support upsert with auto-incrementing primary
-            // keys, but butane isn't well set up to take advantage of that, including missing
-            // support for constraints and the `insert_or_update` method not providing a way to
-            // retrieve the pk.
-            if butane::PrimaryKeyType::is_valid(self.pk()) {
-                #(#values_no_pk)*
-                conn.update(
-                    Self::TABLE,
-                    pkcol,
-                    butane::ToSql::to_sql_ref(self.pk()),
-                    &[#save_cols],
-                    &values,
-                )?;
-                None
-            } else {
-                #(#values)*
-                let pk = conn.insert_returning_pk(Self::TABLE, &[#insert_cols], &pkcol, &values)?;
-                Some(butane::FromSql::from_sql(pk)?)
-            };
-        )
-    } else {
-        // do an upsert
-        quote!(
-            {
-                #(#values)*
-                conn.insert_or_replace(Self::TABLE, &[#insert_cols], &pkcol, &values)?;
-                None
-            };
-        )
-    };
 
     let many_save: TokenStream2 = fields(ast_struct)
         .filter(|f| is_many_to_many(f))
@@ -108,29 +63,40 @@ pub fn impl_dbobject(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
     quote!(
         #dataresult
 
+        impl butane::internal::DataObjectInternal for #tyname {
+            const NON_AUTO_COLUMNS: &'static [butane::db::Column] = &[
+                                #insert_cols
+            ];
+
+            fn pk_mut(&mut self) -> &mut impl butane::PrimaryKeyType {
+                &mut self.#pkident
+            }
+            fn save_many_to_many(&mut self, conn: &impl butane::db::ConnectionMethods) -> butane::Result<()> {
+                #many_save
+                Ok(())
+            }
+            fn values(&self, include_pk: bool) -> Vec<butane::SqlValRef> {
+                let mut values: Vec<butane::SqlValRef> = Vec::with_capacity(
+                    <Self as butane::DataResult>::COLUMNS.len()
+                );
+                if (include_pk) {
+                    #(#values)*
+                } else {
+                    #(#values_no_pk)*
+                }
+                values
+            }
+        }
+
         impl butane::DataObject for #tyname {
             type PKType = #pktype;
             type Fields = #fields_type;
             const PKCOL: &'static str = #pklit;
             const TABLE: &'static str = #tablelit;
             const AUTO_PK: bool = #auto_pk;
+
             fn pk(&self) -> &Self::PKType {
                 &self.#pkident
-            }
-            fn save(&mut self, conn: &impl butane::db::ConnectionMethods) -> butane::Result<()> {
-                //future perf improvement use an array on the stack
-                let mut values: Vec<butane::SqlValRef> = Vec::with_capacity(
-                    <Self as butane::DataResult>::COLUMNS.len()
-                );
-                let pkcol = butane::db::Column::new(
-                    Self::PKCOL,
-                    <Self::PKType as butane::FieldType>::SQLTYPE);
-                let new_pk = #save_core
-                if let Some(new_pk) = new_pk {
-                    self.#pkident = new_pk;
-                }
-                #many_save
-                Ok(())
             }
         }
         impl butane::ToSql for #tyname {

--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -65,7 +65,7 @@ pub fn impl_dbobject(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
 
         impl butane::internal::DataObjectInternal for #tyname {
             const NON_AUTO_COLUMNS: &'static [butane::db::Column] = &[
-                                #insert_cols
+                #insert_cols
             ];
 
             fn pk_mut(&mut self) -> &mut impl butane::PrimaryKeyType {

--- a/butane_core/src/lib.rs
+++ b/butane_core/src/lib.rs
@@ -43,7 +43,7 @@ pub trait DataResult: Sized {
     /// Corresponding object type.
     type DBO: DataObject;
 
-    /// Metadata for eaCH column.
+    /// Metadata for each column.
     const COLUMNS: &'static [Column];
 
     /// Load an object from a database backend row.
@@ -55,11 +55,36 @@ pub trait DataResult: Sized {
     fn query() -> Query<Self>;
 }
 
+pub mod internal {
+    //! Internals called by Butane codegen. Semver exempt.
+
+    use super::*;
+
+    /// Methods implemented by Butane codegen and called by other
+    /// parts of Butane. You do not need to call these directly
+    /// WARNING: Semver exempt
+    pub trait DataObjectInternal: DataResult<DBO = Self> {
+        /// Like [DataResult::COLUMNS] but omits [AutoPk].
+        const NON_AUTO_COLUMNS: &'static [Column];
+
+        /// Get the primary key as mutable. Used internally in the case of [AutoPk].
+        fn pk_mut(&mut self) -> &mut impl PrimaryKeyType;
+
+        /// Saves many-to-many relationships pointed to by fields on this model.
+        /// Performed automatically by `save`. You do not need to call this directly.
+        fn save_many_to_many(&mut self, conn: &impl ConnectionMethods) -> Result<()>;
+
+        /// Returns the Sql values of all columns. Used internally. You are
+        /// unlikely to need to call this directly.
+        fn values(&self, include_pk: bool) -> Vec<SqlValRef>;
+    }
+}
+
 /// An object in the database.
 ///
 /// Rather than implementing this type manually, use the
 /// `#[model]` attribute.
-pub trait DataObject: DataResult<DBO = Self> {
+pub trait DataObject: DataResult<DBO = Self> + internal::DataObjectInternal {
     /// The type of the primary key field.
     type PKType: PrimaryKeyType;
     /// Link to a generated struct providing query helpers for each field.
@@ -74,6 +99,7 @@ pub trait DataObject: DataResult<DBO = Self> {
 
     /// Get the primary key
     fn pk(&self) -> &Self::PKType;
+
     /// Find this object in the database based on primary key.
     /// Returns `Error::NoSuchObject` if the primary key does not exist.
     fn get(conn: &impl ConnectionMethods, id: impl ToSql) -> Result<Self>
@@ -99,7 +125,52 @@ pub trait DataObject: DataResult<DBO = Self> {
             .nth(0))
     }
     /// Save the object to the database.
-    fn save(&mut self, conn: &impl ConnectionMethods) -> Result<()>;
+    fn save(&mut self, conn: &impl ConnectionMethods) -> Result<()> {
+        let pkcol = Column::new(Self::PKCOL, <Self::PKType as FieldType>::SQLTYPE);
+
+        if Self::AUTO_PK && <Self as DataResult>::COLUMNS.len() == 1 {
+            // Our only field is an AutoPk
+            if !self.pk().is_valid() {
+                let pk = conn.insert_returning_pk(Self::TABLE, &[], &pkcol, &[])?;
+                self.pk_mut().initialize(pk)?;
+            }
+        } else if Self::AUTO_PK {
+            // We have an AutoPk, but we also have other fields
+            // Since we expect our pk field to be invalid and to be created by the insert,
+            // we do a pure insert or update based on whether the AutoPk is already valid or not.
+            // Note that some database backends do support upsert with auto-incrementing primary
+            // keys, but butane isn't well set up to take advantage of that, including missing
+            // support for constraints and the `insert_or_update` method not providing a way to
+            // retrieve the pk.
+            if self.pk().is_valid() {
+                // pk is valid, do an update
+                conn.update(
+                    Self::TABLE,
+                    pkcol,
+                    self.pk().to_sql_ref(),
+                    Self::NON_AUTO_COLUMNS,
+                    &self.values(false),
+                )?;
+            } else {
+                // invalid pk, do an insert
+                let pk = conn.insert_returning_pk(
+                    Self::TABLE,
+                    Self::NON_AUTO_COLUMNS,
+                    &pkcol,
+                    &self.values(true),
+                )?;
+                self.pk_mut().initialize(pk)?;
+            };
+        } else {
+            // No AutoPk to worry about, do an upsert
+            conn.insert_or_replace(Self::TABLE, Self::COLUMNS, &pkcol, &self.values(true))?;
+        }
+
+        self.save_many_to_many(conn)?;
+
+        Ok(())
+    }
+
     /// Delete the object from the database.
     fn delete(&self, conn: &impl ConnectionMethods) -> Result<()> {
         conn.delete(Self::TABLE, Self::PKCOL, self.pk().to_sql())

--- a/butane_core/src/migrations/mod.rs
+++ b/butane_core/src/migrations/mod.rs
@@ -274,17 +274,24 @@ impl DataObject for ButaneMigration {
     fn pk(&self) -> &String {
         &self.name
     }
-    fn save(&mut self, conn: &impl ConnectionMethods) -> Result<()> {
-        let mut values: Vec<SqlValRef<'_>> = Vec::with_capacity(2usize);
-        values.push(self.name.to_sql_ref());
-        conn.insert_or_replace(
-            Self::TABLE,
-            <Self as DataResult>::COLUMNS,
-            &Column::new(Self::PKCOL, SqlType::Text),
-            &values,
-        )
-    }
     fn delete(&self, conn: &impl ConnectionMethods) -> Result<()> {
         conn.delete(Self::TABLE, Self::PKCOL, self.pk().to_sql())
+    }
+}
+
+impl crate::internal::DataObjectInternal for ButaneMigration {
+    const NON_AUTO_COLUMNS: &'static [Column] = Self::COLUMNS;
+    fn pk_mut(&mut self) -> &mut String {
+        &mut self.name
+    }
+    fn values(&self, include_pk: bool) -> Vec<SqlValRef> {
+        let mut values: Vec<SqlValRef<'_>> = Vec::with_capacity(2usize);
+        if include_pk {
+            values.push(self.name.to_sql_ref());
+        }
+        values
+    }
+    fn save_many_to_many(&mut self, _conn: &impl ConnectionMethods) -> Result<()> {
+        Ok(()) // no-op
     }
 }

--- a/butane_core/src/sqlval.rs
+++ b/butane_core/src/sqlval.rs
@@ -298,6 +298,16 @@ pub trait PrimaryKeyType: FieldType + Clone + PartialEq {
     fn is_valid(&self) -> bool {
         true
     }
+
+    /// Initialize an invalid primary key with a value.
+    /// No-op if `self.is_valid()` is true.
+    /// Only relevant for `AutoPk`
+    fn initialize(&mut self, value: SqlVal) -> Result<()> {
+        if !self.is_valid() {
+            *self = Self::from_sql(value)?;
+        }
+        Ok(())
+    }
 }
 
 /// Trait for referencing the primary key for a given model. Used to


### PR DESCRIPTION
Generated code is challenging to write and even more challenging to debug. As part of a gradual effort to reduce the amount (or at least complexity) of generated code, move the `DataObject::save` method out of codegen, with a handful of simpler helpers needed by that method generated instead.

This is a refactoring changes. No difference is expected in API surface or result