### PR TITLE
Create dir before lock

### DIFF
--- a/butane_core/src/migrations/fsmigrations.rs
+++ b/butane_core/src/migrations/fsmigrations.rs
@@ -205,9 +205,9 @@ impl MigrationMut for FsMigration {
 
 impl Migration for FsMigration {
     fn db(&self) -> Result<ADB> {
+        self.ensure_dir()?;
         let _lock = self.lock_shared()?;
         let mut db = ADB::new();
-        self.ensure_dir()?;
         let entries = self.fs.list_dir(&self.root)?;
         for entry in entries {
             match entry.file_name() {

--- a/butane_test_helper/src/lib.rs
+++ b/butane_test_helper/src/lib.rs
@@ -194,6 +194,11 @@ pub fn setup_db(backend: Box<dyn Backend>, conn: &mut Connection, migrate: bool)
     migrations::copy_migration(disk_current, mem_current).unwrap();
 
     assert!(
+        disk_current.db().unwrap().tables().count() != 0,
+        "No tables to migrate"
+    );
+
+    assert!(
         mem_migrations
             .create_migration(&nonempty::nonempty![backend], "init", None)
             .expect("expected to create migration without error"),


### PR DESCRIPTION
Related to https://github.com/Electron100/butane/issues/56

Logically, this seems to be correct.
However, I dont want to assume this fixes it.   I did a lot of repeats of running all the tests, and havent seen this problem re-occur.  But I cant reliably reproduce it, so cant be certain this has fixed it.
The question remains, how did the migrations get into this state?