### PR TITLE
Clean butane/.butane only during cargo test

### DIFF
--- a/butane/build.rs
+++ b/butane/build.rs
@@ -1,4 +1,10 @@
 fn main() {
+    // This build.rs is only needed to help the tests
+    if std::env::var("CARGO_CFG_TEST").is_err() {
+        return;
+    }
+    println!("cargo:rerun-if-changed=tests");
+
     // This cleans the .butane/ directory which is generated when compiling the tests so that
     // the tests do not encounter side effects from previous test runs.
     // Currently the only way to remove stale items from the generated .butane/ directory is to
@@ -6,15 +12,10 @@ fn main() {
     // This means we can not rely on `butane clean` or the code behind it, because it hasnt
     // been compiled yet.
     let dir = ".butane/";
-    println!("cargo:rerun-if-changed={dir}");
     if std::path::Path::new(&dir).is_dir() {
-        match std::fs::remove_dir_all(dir) {
-            Ok(_) => {
-                // Re-create the directory. Only tests populate it and if it is left non-existent
-                // Cargo will detect it as changed and a no-op build will not in fact no-op
-                std::fs::create_dir(dir).unwrap();
-            }
-            Err(_) => eprintln!("Cannot delete .butane dir"),
+        println!("cargo:warning=Deleting .butane directory");
+        if std::fs::remove_dir_all(dir).is_err() {
+            println!("cargo:warning=Cannot delete .butane directory");
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Electron100/butane/issues/56

Also only re-run build.rs if the tests/ change.