### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
       with:
         toolchain: nightly
         components: rustfmt
+    - name: Add Rust nightly toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
     - name: Install Rust tools
       run: cargo install typos-cli
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,12 @@ jobs:
     - name: Lint
       run: make lint-ci
     - name: Test Core
-      run: cd butane_core && cargo test --all-features
+      run: cd butane_core && cargo +stable test --all-features
     - name: Test Codegen
-      run: cd butane_codegen && cargo test --all-features
+      run: cd butane_codegen && cargo +stable test --all-features
     - name: Test CLI
-      run: cd butane_cli && cargo test --all-features
+      run: cd butane_cli && cargo +stable test --all-features
     - name: Run example cli tests
-      run: cd example && cargo test --all-features
+      run: cd example && cargo +stable test --all-features
     - name: Test
-      run: cd butane && cargo test --all-features
+      run: cd butane && cargo +stable test --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       # Postgresql setup adapted from Diesel CI
       # Disable ssl as server doesn't have a trusted cert
     - name: Setup postgres on Linux


### PR DESCRIPTION
CI broke on main https://github.com/Electron100/butane/actions/runs/8401909942/job/23019123599
while it was green at https://github.com/Electron100/butane/pull/221

```
error: fields `id`, `title`, and `pub_time` are never read
Error:   --> butane/tests/common/blog.rs:73:9
   |
72 | pub struct PostMetadata {
   |            ------------ fields in this struct
73 |     pub id: i64,
   |         ^^
74 |     pub title: String,
   |         ^^^^^
75 |     #[cfg(feature = "datetime")]
76 |     pub pub_time: Option<NaiveDateTime>,
   |         ^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`

error: could not compile `butane` (test "fake") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: field `pub_time` is never read
Error:   --> butane/tests/common/blog.rs:76:9
   |
[72](https://github.com/jayvdb/butane/actions/runs/8405991704/job/23019393419#step:15:73) | pub struct PostMetadata {
   |            ------------ field in this struct
...
76 |     pub pub_time: Option<NaiveDateTime>,
   |         ^^^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`

error: could not compile `butane` (test "query") due to 1 previous error
Error: Process completed with exit code 101.
```

I'm not sure why, but this appears to fix it.  I suspect the default rust on these images is a bit old.