### PR TITLE
Fix nightly rustc warnings in generated impls

### DIFF
--- a/butane/tests/common/blog.rs
+++ b/butane/tests/common/blog.rs
@@ -1,5 +1,5 @@
-use butane::prelude::*;
-use butane::{dataresult, model};
+//! Helpers for several tests.
+use butane::{dataresult, model, DataObject};
 use butane::{db::Connection, ForeignKey, Many};
 #[cfg(feature = "datetime")]
 use chrono::{naive::NaiveDateTime, offset::Utc};

--- a/butane_core/src/migrations/mod.rs
+++ b/butane_core/src/migrations/mod.rs
@@ -315,7 +315,7 @@ impl crate::internal::DataObjectInternal for ButaneMigration {
     fn pk_mut(&mut self) -> &mut impl PrimaryKeyType {
         &mut self.name
     }
-    fn values(&self, include_pk: bool) -> Vec<SqlValRef> {
+    fn non_auto_values(&self, include_pk: bool) -> Vec<SqlValRef> {
         let mut values: Vec<SqlValRef<'_>> = Vec::with_capacity(2usize);
         if include_pk {
             values.push(self.name.to_sql_ref());


### PR DESCRIPTION
I use https://github.com/dtolnay/cargo-expand quite a bit, and the generated code atm emits lots of "redundant import", "mut not needed", etc.

