### PR TITLE
Clone ForeignKey val

### DIFF
--- a/butane_core/src/fkey.rs
+++ b/butane_core/src/fkey.rs
@@ -1,7 +1,6 @@
 //! Implementation of foreign key relationships between models.
 #![deny(missing_docs)]
 use std::borrow::Cow;
-use std::fmt::{Debug, Formatter};
 
 #[cfg(feature = "fake")]
 use fake::{Dummy, Faker};
@@ -28,6 +27,7 @@ use crate::{
 ///   blog: ForeignKey<Blog>,
 ///   ...
 /// }
+#[derive(Clone, Debug)]
 pub struct ForeignKey<T>
 where
     T: DataObject,
@@ -105,17 +105,6 @@ impl<T: DataObject> From<&T> for ForeignKey<T> {
         Self::from_pk(obj.pk().clone())
     }
 }
-impl<T: DataObject> Clone for ForeignKey<T> {
-    fn clone(&self) -> Self {
-        // Once specialization lands, it would be nice to clone val if
-        // it's clone-able. Then we wouldn't have to ensure the pk
-        self.ensure_valpk();
-        ForeignKey {
-            val: OnceCell::new(),
-            valpk: self.valpk.clone(),
-        }
-    }
-}
 
 impl<T> AsPrimaryKey<T> for ForeignKey<T>
 where
@@ -127,11 +116,6 @@ where
 }
 
 impl<T: DataObject> Eq for ForeignKey<T> {}
-impl<T: DataObject> Debug for ForeignKey<T> {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        self.ensure_valpk().fmt(f)
-    }
-}
 
 impl<T> ToSql for ForeignKey<T>
 where


### PR DESCRIPTION
`Many` clone includes the values, so it is unexpected that `ForeignKey` doesn't behave the same way.
This is more of a problem when cloning a DataObject which contains a ForeignKey, only to find that the `val` is missing and `.get()` needs to be called, which requires fetching from the database again.

Also often I find the custom Debug formatter of `ForeignKey` leaves me wondering if the `.val` has been fetched.