### PR TITLE
Add migrate & unmigrate core helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,18 @@ jobs:
       run: cd butane_codegen && cargo +stable test --all-features
     - name: Test CLI
       run: cd butane_cli && cargo +stable test --all-features
-    - name: Run example cli tests
-      run: cd example && cargo +stable test --all-features
     - name: Test
       run: cd butane && cargo +stable test --all-features
-    - name: Check example migrations
+    - name: Check example migrations have been updated
       run: |
         set -ex
         make regenerate-example-migrations
         git add -A
         git diff --exit-code
+    - name: Run tests in examples
+      run: |
+        cargo +stable test -p example --all-features
+        cd examples
+        for dir in *; do
+          cargo +stable test -p $dir --all-features
+        done

--- a/butane/tests/migration-tests.rs
+++ b/butane/tests/migration-tests.rs
@@ -1,7 +1,8 @@
-use butane::migrations::adb::{DeferredSqlType, TypeIdentifier, TypeKey};
-use butane::migrations::{MemMigrations, Migration, MigrationMut, Migrations, MigrationsMut};
-use butane::{db::Connection, prelude::*, SqlType, SqlVal};
 use butane_core::codegen::{butane_type_with_migrations, model_with_migrations};
+use butane_core::db::{BackendConnection, Connection};
+use butane_core::migrations::adb::{DeferredSqlType, TypeIdentifier, TypeKey};
+use butane_core::migrations::{MemMigrations, Migration, MigrationMut, Migrations, MigrationsMut};
+use butane_core::{SqlType, SqlVal};
 #[cfg(feature = "pg")]
 use butane_test_helper::pg_connection;
 #[cfg(feature = "sqlite")]

--- a/butane/tests/migration-tests.rs
+++ b/butane/tests/migration-tests.rs
@@ -1,5 +1,5 @@
 use butane::migrations::adb::{DeferredSqlType, TypeIdentifier, TypeKey};
-use butane::migrations::{self, MemMigrations, Migration, MigrationMut, Migrations, MigrationsMut};
+use butane::migrations::{MemMigrations, Migration, MigrationMut, Migrations, MigrationsMut};
 use butane::{db::Connection, prelude::*, SqlType, SqlVal};
 use butane_core::codegen::{butane_type_with_migrations, model_with_migrations};
 #[cfg(feature = "pg")]
@@ -344,7 +344,7 @@ fn test_migrate(
     let to_apply = ms.unapplied_migrations(conn).unwrap();
     assert_eq!(to_apply.len(), 2);
 
-    migrations::migrate(conn, &ms).unwrap();
+    ms.migrate(conn).unwrap();
 
     let to_apply = ms.unapplied_migrations(conn).unwrap();
     assert_eq!(to_apply.len(), 0);
@@ -352,7 +352,7 @@ fn test_migrate(
     verify_sql(conn, &ms, expected_up_sql, expected_down_sql);
 
     // Now downgrade, just to make sure we can
-    migrations::rollback(conn, &ms).unwrap();
+    ms.unmigrate(conn).unwrap();
 
     let to_apply = ms.unapplied_migrations(conn).unwrap();
     assert_eq!(to_apply.len(), 2);
@@ -563,7 +563,7 @@ fn migration_delete_table(conn: &mut Connection, expected_up_sql: &str, expected
     let to_apply = ms.unapplied_migrations(conn).unwrap();
     assert_eq!(to_apply.len(), 2);
 
-    migrations::migrate(conn, &ms).unwrap();
+    ms.migrate(conn).unwrap();
 
     let to_apply = ms.unapplied_migrations(conn).unwrap();
     assert_eq!(to_apply.len(), 0);
@@ -571,7 +571,7 @@ fn migration_delete_table(conn: &mut Connection, expected_up_sql: &str, expected
     verify_sql(conn, &ms, expected_up_sql, expected_down_sql);
 
     // Now downgrade, just to make sure we can
-    migrations::rollback(conn, &ms).unwrap();
+    ms.unmigrate(conn).unwrap();
 
     let to_apply = ms.unapplied_migrations(conn).unwrap();
     assert_eq!(to_apply.len(), 2);

--- a/butane_test_helper/src/lib.rs
+++ b/butane_test_helper/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 
 use block_id::{Alphabet, BlockId};
 use butane_core::db::{connect, get_backend, pg, sqlite, Backend, Connection, ConnectionSpec};
-use butane_core::migrations::{self, MemMigrations, Migration, Migrations, MigrationsMut};
+use butane_core::migrations::{self, MemMigrations, Migration, MigrationsMut};
 use once_cell::sync::Lazy;
 use uuid::Uuid;
 
@@ -209,11 +209,7 @@ pub fn setup_db(backend: Box<dyn Backend>, conn: &mut Connection, migrate: bool)
         "expected to create migration"
     );
     log::info!("created current migration");
-    let to_apply = mem_migrations.unapplied_migrations(conn).unwrap();
-    for m in to_apply {
-        log::info!("Applying migration {}", m.name());
-        m.apply(conn).unwrap();
-    }
+    migrations::migrate(conn, &mem_migrations).unwrap();
 }
 
 /// Create a sqlite [`Connection`].

--- a/butane_test_helper/src/lib.rs
+++ b/butane_test_helper/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 
 use block_id::{Alphabet, BlockId};
 use butane_core::db::{connect, get_backend, pg, sqlite, Backend, Connection, ConnectionSpec};
-use butane_core::migrations::{self, MemMigrations, Migration, MigrationsMut};
+use butane_core::migrations::{self, MemMigrations, Migration, Migrations, MigrationsMut};
 use once_cell::sync::Lazy;
 use uuid::Uuid;
 
@@ -209,7 +209,7 @@ pub fn setup_db(backend: Box<dyn Backend>, conn: &mut Connection, migrate: bool)
         "expected to create migration"
     );
     log::info!("created current migration");
-    migrations::migrate(conn, &mem_migrations).unwrap();
+    mem_migrations.migrate(conn).unwrap();
 }
 
 /// Create a sqlite [`Connection`].

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -505,11 +505,11 @@ to use these migrations:
 
 ``` rust
 pub fn establish_connection() -> Connection {
-    use butane::migrations;
+    use butane::migrations::Migrations;
 
     let mut connection = butane::db::connect(&ConnectionSpec::load(".butane/connection.json").unwrap()).unwrap();
     let migrations = butane_migrations::get_migrations().unwrap();
-    migrations::migrate(&mut connection, &migrations).unwrap();
+    migrations.migrate(&mut connection).unwrap();
     connection
 }
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -505,14 +505,11 @@ to use these migrations:
 
 ``` rust
 pub fn establish_connection() -> Connection {
-    use butane::migrations::{Migration, Migrations};
+    use butane::migrations;
 
     let mut connection = butane::db::connect(&ConnectionSpec::load(".butane/connection.json").unwrap()).unwrap();
     let migrations = butane_migrations::get_migrations().unwrap();
-    let to_apply = migrations.unapplied_migrations(&connection).unwrap();
-    for migration in to_apply {
-        migration.apply(&mut connection).unwrap();
-    }
+    migrations::migrate(&mut connection, &migrations).unwrap();
     connection
 }
 ```

--- a/examples/getting_started/src/lib.rs
+++ b/examples/getting_started/src/lib.rs
@@ -6,7 +6,7 @@ pub mod butane_migrations;
 pub mod models;
 
 use butane::db::{Connection, ConnectionSpec};
-use butane::migrations;
+use butane::migrations::Migrations;
 use butane::prelude::*;
 use models::{Blog, Post};
 
@@ -15,7 +15,7 @@ pub fn establish_connection() -> Connection {
     let mut connection =
         butane::db::connect(&ConnectionSpec::load(".butane/connection.json").unwrap()).unwrap();
     let migrations = butane_migrations::get_migrations().unwrap();
-    migrations::migrate(&mut connection, &migrations).unwrap();
+    migrations.migrate(&mut connection).unwrap();
     connection
 }
 

--- a/examples/getting_started/src/lib.rs
+++ b/examples/getting_started/src/lib.rs
@@ -6,7 +6,7 @@ pub mod butane_migrations;
 pub mod models;
 
 use butane::db::{Connection, ConnectionSpec};
-use butane::migrations::{Migration, Migrations};
+use butane::migrations;
 use butane::prelude::*;
 use models::{Blog, Post};
 
@@ -15,10 +15,7 @@ pub fn establish_connection() -> Connection {
     let mut connection =
         butane::db::connect(&ConnectionSpec::load(".butane/connection.json").unwrap()).unwrap();
     let migrations = butane_migrations::get_migrations().unwrap();
-    let to_apply = migrations.unapplied_migrations(&connection).unwrap();
-    for migration in to_apply {
-        migration.apply(&mut connection).unwrap();
-    }
+    migrations::migrate(&mut connection, &migrations).unwrap();
     connection
 }
 

--- a/examples/getting_started/tests/rollback.rs
+++ b/examples/getting_started/tests/rollback.rs
@@ -1,5 +1,5 @@
 use butane::db::{BackendConnection, Connection};
-use butane::migrations::{Migration, Migrations};
+use butane::migrations;
 use butane::DataObject;
 use butane_test_helper::*;
 
@@ -38,22 +38,12 @@ fn migrate_and_rollback(mut connection: Connection) {
     // Migrate forward.
     let base_dir = std::path::PathBuf::from(".butane");
     let migrations = butane_cli::get_migrations(&base_dir).unwrap();
-    let to_apply = migrations.unapplied_migrations(&connection).unwrap();
-    for migration in &to_apply {
-        migration
-            .apply(&mut connection)
-            .unwrap_or_else(|err| panic!("migration {} failed: {err}", migration.name()));
-        eprintln!("Applied {}", migration.name());
-    }
+
+    migrations::migrate(&mut connection, &migrations).unwrap();
 
     insert_data(&connection);
 
     // Rollback migrations.
-    for migration in to_apply.iter().rev() {
-        migration
-            .downgrade(&mut connection)
-            .unwrap_or_else(|err| panic!("rollback of {} failed: {err}", migration.name()));
-        eprintln!("Rolled back {}", migration.name());
-    }
+    migrations::rollback(&mut connection, &migrations).unwrap();
 }
 testall_no_migrate!(migrate_and_rollback);

--- a/examples/getting_started/tests/rollback.rs
+++ b/examples/getting_started/tests/rollback.rs
@@ -1,5 +1,5 @@
 use butane::db::{BackendConnection, Connection};
-use butane::migrations;
+use butane::migrations::Migrations;
 use butane::DataObject;
 use butane_test_helper::*;
 
@@ -39,11 +39,11 @@ fn migrate_and_rollback(mut connection: Connection) {
     let base_dir = std::path::PathBuf::from(".butane");
     let migrations = butane_cli::get_migrations(&base_dir).unwrap();
 
-    migrations::migrate(&mut connection, &migrations).unwrap();
+    migrations.migrate(&mut connection).unwrap();
 
     insert_data(&connection);
 
     // Rollback migrations.
-    migrations::rollback(&mut connection, &migrations).unwrap();
+    migrations.unmigrate(&mut connection).unwrap();
 }
 testall_no_migrate!(migrate_and_rollback);

--- a/examples/newtype/src/lib.rs
+++ b/examples/newtype/src/lib.rs
@@ -6,7 +6,7 @@ pub mod butane_migrations;
 pub mod models;
 
 use butane::db::{Connection, ConnectionSpec};
-use butane::migrations;
+use butane::migrations::Migrations;
 use butane::prelude::*;
 use models::{Blog, Post};
 
@@ -15,7 +15,7 @@ pub fn establish_connection() -> Connection {
     let mut connection =
         butane::db::connect(&ConnectionSpec::load(".butane/connection.json").unwrap()).unwrap();
     let migrations = butane_migrations::get_migrations().unwrap();
-    migrations::migrate(&mut connection, &migrations).unwrap();
+    migrations.migrate(&mut connection).unwrap();
     connection
 }
 

--- a/examples/newtype/src/lib.rs
+++ b/examples/newtype/src/lib.rs
@@ -6,7 +6,7 @@ pub mod butane_migrations;
 pub mod models;
 
 use butane::db::{Connection, ConnectionSpec};
-use butane::migrations::{Migration, Migrations};
+use butane::migrations;
 use butane::prelude::*;
 use models::{Blog, Post};
 
@@ -15,10 +15,7 @@ pub fn establish_connection() -> Connection {
     let mut connection =
         butane::db::connect(&ConnectionSpec::load(".butane/connection.json").unwrap()).unwrap();
     let migrations = butane_migrations::get_migrations().unwrap();
-    let to_apply = migrations.unapplied_migrations(&connection).unwrap();
-    for migration in to_apply {
-        migration.apply(&mut connection).unwrap();
-    }
+    migrations::migrate(&mut connection, &migrations).unwrap();
     connection
 }
 

--- a/examples/newtype/tests/rollback.rs
+++ b/examples/newtype/tests/rollback.rs
@@ -33,7 +33,7 @@ fn migrate_and_rollback(mut connection: Connection) {
     let migrations = butane_cli::get_migrations(&base_dir).unwrap();
     let to_apply = migrations.unapplied_migrations(&connection).unwrap();
 
-    migrations::migrate(&mut connection, &migrations).unwrap();
+    migrations.migrate(&mut connection).unwrap();
 
     insert_data(&connection);
 

--- a/examples/newtype/tests/rollback.rs
+++ b/examples/newtype/tests/rollback.rs
@@ -1,5 +1,5 @@
 use butane::db::{BackendConnection, Connection};
-use butane::migrations::{self, Migration, Migrations};
+use butane::migrations::{Migration, Migrations};
 use butane::DataObject;
 use butane_test_helper::*;
 

--- a/examples/newtype/tests/rollback.rs
+++ b/examples/newtype/tests/rollback.rs
@@ -1,5 +1,5 @@
 use butane::db::{BackendConnection, Connection};
-use butane::migrations::{Migration, Migrations};
+use butane::migrations::{self, Migration, Migrations};
 use butane::DataObject;
 use butane_test_helper::*;
 
@@ -32,12 +32,8 @@ fn migrate_and_rollback(mut connection: Connection) {
     let base_dir = std::path::PathBuf::from(".butane");
     let migrations = butane_cli::get_migrations(&base_dir).unwrap();
     let to_apply = migrations.unapplied_migrations(&connection).unwrap();
-    for migration in &to_apply {
-        migration
-            .apply(&mut connection)
-            .unwrap_or_else(|err| panic!("migration {} failed: {err}", migration.name()));
-        eprintln!("Applied {}", migration.name());
-    }
+
+    migrations::migrate(&mut connection, &migrations).unwrap();
 
     insert_data(&connection);
 


### PR DESCRIPTION
These helpers could be placed on `Migrations` or on `BackendConnection`, but it feels sensible to keep them separate and use these helpers to join them.  Keen to reconsider that.

My reason for keeping them simple is anyone invoking these helpers can also play with the connection and migrations in advance, either to detect any problems in advance, or after, and editing the migrations to control the start / end of the migrate/rollback operations.

I'm also not keen on trying to use these helpers in `butane_cli`, as it would require moving a lot of CLI-ish feedback into an `Err`, but I am happy to do that - probably by creating a new `Error` enum for this.
