### PR TITLE
Add test to unmigrate test models

### DIFF
--- a/butane/tests/r2d2.rs
+++ b/butane/tests/r2d2.rs
@@ -19,11 +19,7 @@ fn r2d2_sqlite() {
         let mut conn1 = pool.get().unwrap();
         assert_eq!(pool.state().connections, 3);
         assert_eq!(pool.state().idle_connections, 2);
-        setup_db(
-            Box::new(butane::db::sqlite::SQLiteBackend::new()),
-            &mut conn1,
-            true,
-        );
+        setup_db(&mut conn1);
 
         let _conn2 = pool.get().unwrap();
         assert_eq!(pool.state().idle_connections, 1);
@@ -42,7 +38,7 @@ fn r2d2_pq() {
         let mut conn1 = pool.get().unwrap();
         assert_eq!(pool.state().connections, 3);
         assert_eq!(pool.state().idle_connections, 2);
-        setup_db(Box::new(butane::db::pg::PgBackend::new()), &mut conn1, true);
+        setup_db(&mut conn1);
 
         let _conn2 = pool.get().unwrap();
         assert_eq!(pool.state().idle_connections, 1);

--- a/butane/tests/unmigrate.rs
+++ b/butane/tests/unmigrate.rs
@@ -1,0 +1,20 @@
+//! Test the "current" migration created by the butane_test_helper due to
+//! all of the other tests in the butane/tests directory.
+#![cfg(test)]
+use butane::db::Connection;
+use butane::migrations::{Migration, Migrations};
+use butane_test_helper::*;
+
+fn unmigrate(mut connection: Connection) {
+    let mem_migrations = create_current_migrations(&connection);
+
+    let migrations = mem_migrations.unapplied_migrations(&connection).unwrap();
+    assert_eq!(migrations.len(), 0);
+
+    let migration = mem_migrations.latest().unwrap();
+    migration.downgrade(&mut connection).unwrap();
+
+    let migrations = mem_migrations.unapplied_migrations(&connection).unwrap();
+    assert_eq!(migrations.len(), 1);
+}
+testall!(unmigrate);


### PR DESCRIPTION
The error I get for pg is
```
thread 'unmigrate_pg' panicked at butane/tests/unmigrate.rs:15:42:
called `Result::unwrap()` on an `Err` value: Postgres(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E2BP01), message: "cannot drop table autoitem because other objects depend on it", detail: Some("constraint autopkwithmany_items_many_has_fkey on table autopkwithmany_items_many depends on table autoitem\nconstraint renamed_many_table_items_many_has_fkey on table renamed_many_table_items_many depends on table autoitem"), hint: Some("Use DROP ... CASCADE to drop the dependent objects too."), position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("dependency.c"), line: Some(1197), routine: Some("reportDependentObjects") }) })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```