### PR TITLE
Cargo still needs explicit version for dependencies when publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ repository = "https://github.com/Electron100/butane"
 version = "0.7.0"
 
 [workspace.dependencies]
-butane = { path = "butane" }
+butane = { version = "0.7", path = "butane" }
 butane_cli = { path = "butane_cli" }
-butane_core = { path = "butane_core" }
-butane_codegen = { path = "butane_codegen" }
+butane_core = { version = "0.7", path = "butane_core" }
+butane_codegen = { version = "0.7", path = "butane_codegen" }
 butane_test_helper = { path = "butane_test_helper" }
 cfg-if = "^1.0"
 chrono = { version = "0.4.25", default-features = false, features = [


### PR DESCRIPTION
I incorrectly removed this in #264 