### PR TITLE
Clean up AsyncAdapter

### DIFF
--- a/async_checklist.md
+++ b/async_checklist.md
@@ -7,7 +7,6 @@
 * [x] Ensure sqlite works in async
 * [x] Fully support sync too. Using async should not be required
 * [ ] Clean up miscellaneous TODOs
-* [ ] Establish soundness for unsafe sections of AsyncAdapter
-* [ ] Consider publishing `AsyncAdapter` into its own crate
+* [x] Establish soundness for unsafe sections of AsyncAdapter
 * [ ] Should async and/or async_adapter be under a separate feature?
 * [ ] Integrate deadpool or bb8 for async connection pool

--- a/butane_core/src/db/mod.rs
+++ b/butane_core/src/db/mod.rs
@@ -81,7 +81,6 @@ mod internal {
 /// Database connection.
 #[maybe_async_cfg::maybe(
     idents(
-        AsyncRequiresSend,
         ConnectionMethods(sync = "ConnectionMethods", async = "ConnectionMethodsAsync"),
         Transaction(sync = "Transaction", async = "TransactionAsync"),
     ),

--- a/butane_core/src/db/mod.rs
+++ b/butane_core/src/db/mod.rs
@@ -29,6 +29,7 @@ use crate::query::{BoolExpr, Order};
 use crate::{migrations::adb, Error, Result, SqlVal, SqlValRef};
 
 mod adapter;
+pub use adapter::connect_async_via_sync;
 pub(crate) mod dummy;
 use dummy::DummyConnection;
 mod sync_adapter;

--- a/butane_core/src/lib.rs
+++ b/butane_core/src/lib.rs
@@ -383,6 +383,8 @@ impl std::fmt::Display for SqlType {
 #[cfg(feature = "log")]
 pub use log::debug;
 #[cfg(feature = "log")]
+pub use log::error;
+#[cfg(feature = "log")]
 pub use log::info;
 #[cfg(feature = "log")]
 pub use log::warn;
@@ -408,6 +410,13 @@ mod btlog {
     /// Noop for when feature log is not enabled.
     #[macro_export]
     macro_rules! warn {
+        (target: $target:expr, $($arg:tt)+) => {};
+        ($($arg:tt)+) => {};
+    }
+
+    /// Noop for when feature log is not enabled.
+    #[macro_export]
+    macro_rules! error {
         (target: $target:expr, $($arg:tt)+) => {};
         ($($arg:tt)+) => {};
     }


### PR DESCRIPTION
Address TODOs, and improve comments including about why I believe the unsafe usage to be sound.
That said, I welcome additional eyes on the unsafe sections here . In some ways I find unsafe in Rust even harder to reason about than memory safety in C++ as Rust has a greater expectation that objects may be allowed to move.