### PR TITLE
Gate async functionality behind a feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,6 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 name = "butane"
 version = "0.7.0"
 dependencies = [
- "async-trait",
  "butane_codegen",
  "butane_core",
  "butane_test_helper",

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build :
 	cd butane && $(CARGO) check --features pg
 	cd butane && $(CARGO) check --features pg,datetime
 	cd butane && $(CARGO) check --features sqlite
+	cd examples/getting_started && $(CARGO) check --features "sqlite,sqlite-bundled"
 	cargo build --all-features
 
 lint :
@@ -21,6 +22,8 @@ check : build doclint lint spellcheck check-fmt test
 
 test :
 	$(CARGO) test --all-features
+	# And run the example tests separately to avoid feature combinations
+	cd examples; for dir in *; do cargo +stable test -p $dir --all-features; done
 
 clean :
 	$(CARGO) clean

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Butane exposes several features to Cargo. By default, no backends are
 enabled: you will want to enable `sqlite` and/or `pg`:
 
 * `default`: Turns on `datetime`, `json` and `uuid`.
+* `async`: Turns on async support. This is automatically enabled for the `pg` backend, which is implemented on the `tokio-postgres` crate.
+* `async-adapter`: Enables the use of `async` with the `sqlite` backend, which is not natively async.
 * `debug`: Used in developing Butane, not expected to be enabled by consumers.
 * `datetime`: Support for timestamps (using [`chrono`](https://crates.io/crates/chrono) crate).
 * `fake`: Support for the [`fake`](https://crates.io/crates/fake) crate's generation of fake data.

--- a/async_checklist.md
+++ b/async_checklist.md
@@ -9,5 +9,5 @@
 * [ ] Clean up miscellaneous TODOs
 * [ ] Establish soundness for unsafe sections of AsyncAdapter
 * [ ] Consider publishing `AsyncAdapter` into its own crate
-* [ ] Should async and/or async_adapter be under a separate feature?
+* [x] Should async and/or async_adapter be under a separate feature?
 * [ ] Integrate deadpool or bb8 for async connection pool

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -13,6 +13,8 @@ documentation = "https://docs.rs/butane/"
 build = "build.rs"
 
 [features]
+async = ["butane_core/async"]
+async-adapter = ["butane_core/async-adapter"]
 default = ["datetime", "json", "uuid"]
 fake = ["butane_core/fake"]
 json = ["butane_codegen/json", "butane_core/json"]
@@ -27,7 +29,6 @@ tls = ["butane_core/tls"]
 uuid = ["butane_codegen/uuid", "butane_core/uuid"]
 
 [dependencies]
-async-trait = { workspace = true }
 butane_codegen = { workspace = true }
 butane_core = { workspace = true }
 

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -13,14 +13,14 @@ documentation = "https://docs.rs/butane/"
 build = "build.rs"
 
 [features]
-async = ["butane_core/async"]
+async = ["butane_core/async", "butane_codegen/async"]
 async-adapter = ["butane_core/async-adapter"]
 default = ["datetime", "json", "uuid"]
 fake = ["butane_core/fake"]
 json = ["butane_codegen/json", "butane_core/json"]
 sqlite = ["butane_core/sqlite"]
 sqlite-bundled = ["butane_core/sqlite-bundled"]
-pg = ["butane_core/pg"]
+pg = ["async", "butane_core/pg"]
 datetime = ["butane_codegen/datetime", "butane_core/datetime"]
 debug = ["butane_core/debug"]
 log = ["butane_core/log"]

--- a/butane/src/lib.rs
+++ b/butane/src/lib.rs
@@ -9,12 +9,14 @@
 pub use butane_codegen::{butane_type, dataresult, model, FieldType, PrimaryKeyType};
 pub use butane_core::custom;
 pub use butane_core::fkey::ForeignKey;
-pub use butane_core::many::{Many, ManyOpsAsync, ManyOpsSync};
+pub use butane_core::many::{Many, ManyOpsSync};
 pub use butane_core::migrations;
 pub use butane_core::query;
+#[cfg(feature = "async")]
+pub use butane_core::{many::ManyOpsAsync, DataObjectOpsAsync};
 pub use butane_core::{
-    AsPrimaryKey, AutoPk, DataObject, DataObjectOpsAsync, DataObjectOpsSync, DataResult, Error,
-    FieldType, FromSql, PrimaryKeyType, Result, SqlType, SqlVal, SqlValRef, ToSql,
+    AsPrimaryKey, AutoPk, DataObject, DataObjectOpsSync, DataResult, Error, FieldType, FromSql,
+    PrimaryKeyType, Result, SqlType, SqlVal, SqlValRef, ToSql,
 };
 
 pub mod db {
@@ -196,6 +198,7 @@ pub mod prelude {
     pub use butane_core::DataObjectOpsSync;
 }
 
+#[cfg(feature = "async")]
 pub mod prelude_async {
     //! Prelude module to improve ergonomics in async operation. Brings certain traits into scope.
     //!
@@ -213,8 +216,6 @@ pub mod internal {
     //! Internals used in macro-generated code.
     //!
     //! Do not use directly. Semver-exempt.
-
-    pub use async_trait::async_trait;
 
     pub use butane_core::internal::*;
 }

--- a/butane_codegen/Cargo.toml
+++ b/butane_codegen/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
+async = ["butane_core/async"]
 datetime = ["butane_core/datetime"]
 json = ["butane_core/json"]
 uuid = ["butane_core/uuid"]

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -10,14 +10,15 @@ repository.workspace = true
 
 
 [features]
-async-adapter = []
+async-adapter = ["async", "crossbeam-channel"]
+async = ["tokio"]
 datetime = ["chrono", "tokio-postgres?/with-chrono-0_4"]
 debug = ["log"]
 fake = ["dep:fake", "rand"]
 json = ["tokio-postgres?/with-serde_json-1", "rusqlite?/serde_json"]
 log = ["dep:log", "rusqlite?/trace"]
-pg = ["bytes", "tokio-postgres"]
-sqlite = ["rusqlite", "async-adapter"]
+pg = ["async", "bytes", "tokio-postgres"]
+sqlite = ["rusqlite"]
 sqlite-bundled = ["rusqlite/bundled"]
 tls = ["native-tls", "postgres-native-tls"]
 
@@ -27,8 +28,7 @@ async-trait = { workspace = true}
 bytes = { version = "1.0", optional = true }
 cfg-if = { workspace = true }
 chrono = { optional = true, workspace = true }
-# todo make adapter optional
-crossbeam-channel = { workspace = true }
+crossbeam-channel = { workspace = true, optional = true}
 dyn-clone = { version = "1.0" }
 fake = { workspace = true, optional = true }
 fallible-iterator = "0.3"
@@ -42,7 +42,7 @@ native-tls = { version = "0.2", optional = true }
 nonempty.workspace = true
 once_cell = { workspace = true }
 pin-project = "1"
-tokio = {workspace = true, features = ["rt", "sync", "rt-multi-thread"]}
+tokio = {workspace = true, optional = true, features = ["rt", "sync", "rt-multi-thread"]}
 tokio-postgres = { optional = true, workspace = true }
 postgres-native-tls = { version = "0.5", optional = true }
 proc-macro2 = { workspace = true }

--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -37,8 +37,8 @@ pub fn impl_dbobject(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
     let values_no_pk: Vec<TokenStream2> = push_values(ast_struct, |f: &Field| f != &pk_field);
     let insert_cols = columns(ast_struct, |f| !is_auto(f));
 
-    let many_save_async = impl_many_save(ast_struct, config, true);
     let many_save_sync = impl_many_save(ast_struct, config, false);
+    let save_many_to_many_async = def_for_save_many_to_many_async(ast_struct, config);
 
     let conn_arg_name = if many_save_sync.is_empty() {
         syn::Ident::new("_conn", Span::call_site())
@@ -83,13 +83,7 @@ pub fn impl_dbobject(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
             fn pk_mut(&mut self) -> &mut impl butane::PrimaryKeyType {
                 &mut self.#pkident
             }
-            async fn save_many_to_many_async(
-                &mut self,
-                #conn_arg_name: &impl butane::db::ConnectionMethodsAsync,
-            ) -> butane::Result<()> {
-                #many_save_async
-                Ok(())
-            }
+            #save_many_to_many_async
             fn save_many_to_many_sync(
                 &mut self,
                 #conn_arg_name: &impl butane::db::ConnectionMethods,
@@ -458,4 +452,29 @@ fn impl_many_save(ast_struct: &ItemStruct, config: &Config, is_async: bool) -> T
             )
         })
         .collect();
+}
+
+#[cfg(feature = "async")]
+fn def_for_save_many_to_many_async(ast_struct: &ItemStruct, config: &Config) -> TokenStream2 {
+    let many_save_async = impl_many_save(ast_struct, config, true);
+    let conn_arg_name = if many_save_async.is_empty() {
+        syn::Ident::new("_conn", Span::call_site())
+    } else {
+        syn::Ident::new("conn", Span::call_site())
+    };
+
+    quote!(
+     async fn save_many_to_many_async(
+            &mut self,
+            #conn_arg_name: &impl butane::db::ConnectionMethodsAsync,
+     ) -> butane::Result<()> {
+            #many_save_async
+            Ok(())
+     }
+    )
+}
+
+#[cfg(not(feature = "async"))]
+fn def_for_save_many_to_many_async(_ast_struct: &ItemStruct, _config: &Config) -> TokenStream2 {
+    quote!()
 }

--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -464,13 +464,13 @@ fn def_for_save_many_to_many_async(ast_struct: &ItemStruct, config: &Config) -> 
     };
 
     quote!(
-     async fn save_many_to_many_async(
+        async fn save_many_to_many_async(
             &mut self,
             #conn_arg_name: &impl butane::db::ConnectionMethodsAsync,
-     ) -> butane::Result<()> {
+        ) -> butane::Result<()> {
             #many_save_async
             Ok(())
-     }
+        }
     )
 }
 

--- a/butane_core/src/db/connmethods.rs
+++ b/butane_core/src/db/connmethods.rs
@@ -14,7 +14,7 @@ use crate::{Result, SqlType, SqlVal, SqlValRef};
 /// implemented by both database connections and transactions.
 #[maybe_async_cfg::maybe(
     sync(keep_self),
-    async(self = "ConnectionMethodsAsync"),
+    async(feature = "async", self = "ConnectionMethodsAsync"),
     idents(AsyncRequiresSync)
 )]
 #[async_trait]
@@ -156,6 +156,7 @@ impl<T> VecRows<T> {
     }
 }
 
+#[cfg(feature = "async-adapter")]
 pub(crate) fn vec_from_backend_rows<'a>(
     mut other: Box<dyn BackendRows + 'a>,
     columns: &[Column],
@@ -191,11 +192,13 @@ impl<'a> BackendRows for Box<dyn BackendRows + 'a> {
     }
 }
 
+#[cfg(feature = "async-adapter")]
 #[derive(Debug)]
 pub(crate) struct VecRow {
     values: Vec<SqlVal>,
 }
 
+#[cfg(feature = "async-adapter")]
 impl VecRow {
     fn new(original: &(dyn BackendRow), columns: &[Column]) -> Result<Self> {
         if original.len() != columns.len() {
@@ -214,6 +217,8 @@ impl VecRow {
         })
     }
 }
+
+#[cfg(feature = "async-adapter")]
 impl BackendRow for VecRow {
     fn get(&self, idx: usize, ty: SqlType) -> Result<SqlValRef> {
         self.values

--- a/butane_core/src/db/dummy.rs
+++ b/butane_core/src/db/dummy.rs
@@ -116,7 +116,7 @@ impl ConnectionMethods for DummyConnection {
     ),
     keep_self,
     sync(),
-    async()
+    async(feature = "async")
 )]
 #[async_trait]
 impl BackendConnection for DummyConnection {

--- a/butane_core/src/db/macros.rs
+++ b/butane_core/src/db/macros.rs
@@ -8,7 +8,7 @@ macro_rules! connection_method_wrapper {
                 Transaction(sync = "Transaction")
             ),
             sync(keep_self),
-            async()
+            async(feature = "async")
         )]
         #[async_trait::async_trait]
         impl ConnectionMethods for $ty {

--- a/butane_core/src/fkey.rs
+++ b/butane_core/src/fkey.rs
@@ -8,10 +8,12 @@ use std::sync::OnceLock;
 use fake::{Dummy, Faker};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::util::{get_or_init_once_lock, get_or_init_once_lock_async};
+use crate::util::get_or_init_once_lock;
+#[cfg(feature = "async")]
+use crate::{util::get_or_init_once_lock_async, ConnectionMethodsAsync};
 use crate::{
-    AsPrimaryKey, ConnectionMethods, ConnectionMethodsAsync, DataObject, Error, FieldType, FromSql,
-    Result, SqlType, SqlVal, SqlValRef, ToSql,
+    AsPrimaryKey, ConnectionMethods, DataObject, Error, FieldType, FromSql, Result, SqlType,
+    SqlVal, SqlValRef, ToSql,
 };
 
 /// Used to implement a relationship between models.
@@ -92,7 +94,7 @@ impl<T: DataObject> ForeignKey<T> {
 #[maybe_async_cfg::maybe(
     idents(ConnectionMethods(sync = "ConnectionMethods"),),
     sync(),
-    async()
+    async(feature = "async")
 )]
 pub trait ForeignKeyOps<T: DataObject> {
     /// Loads the value referred to by this foreign key from the
@@ -102,6 +104,7 @@ pub trait ForeignKeyOps<T: DataObject> {
         T: 'a;
 }
 
+#[cfg(feature = "async")]
 impl<T: DataObject> ForeignKeyOpsAsync<T> for ForeignKey<T> {
     async fn load<'a>(&'a self, conn: &impl ConnectionMethodsAsync) -> Result<&'a T>
     where

--- a/butane_core/src/migrations/mod.rs
+++ b/butane_core/src/migrations/mod.rs
@@ -9,10 +9,9 @@ use async_trait::async_trait;
 use fallible_iterator::FallibleIterator;
 use nonempty::NonEmpty;
 
-use crate::db::{
-    Backend, BackendConnection, BackendRows, Column, ConnectionAsync, ConnectionMethods,
-    ConnectionMethodsAsync,
-};
+use crate::db::{Backend, BackendConnection, BackendRows, Column, ConnectionMethods};
+#[cfg(feature = "async")]
+use crate::db::{ConnectionAsync, ConnectionMethodsAsync};
 use crate::sqlval::{FromSql, SqlValRef, ToSql};
 use crate::{db, query, DataObject, DataResult, Error, PrimaryKeyType, Result, SqlType};
 
@@ -124,6 +123,7 @@ pub trait Migrations: Clone {
         Ok(())
     }
 
+    #[cfg(feature = "async")]
     /// Migrate connection forward.
     async fn migrate_async(&self, conn: &mut ConnectionAsync) -> Result<()>
     where
@@ -156,6 +156,7 @@ pub trait Migrations: Clone {
     }
 
     /// Remove all applied migrations.
+    #[cfg(feature = "async")]
     async fn unmigrate_async(&self, conn: &mut ConnectionAsync) -> Result<()>
     where
         Self: Send + 'static,
@@ -381,6 +382,7 @@ impl crate::internal::DataObjectInternal for ButaneMigration {
         }
         values
     }
+    #[cfg(feature = "async")]
     async fn save_many_to_many_async(&mut self, _conn: &impl ConnectionMethodsAsync) -> Result<()> {
         Ok(()) // no-op
     }

--- a/butane_core/src/query/mod.rs
+++ b/butane_core/src/query/mod.rs
@@ -9,7 +9,9 @@ use std::marker::PhantomData;
 
 use fallible_iterator::FallibleIterator;
 
-use crate::db::{BackendRows, ConnectionMethods, ConnectionMethodsAsync, QueryResult};
+#[cfg(feature = "async")]
+use crate::db::ConnectionMethodsAsync;
+use crate::db::{BackendRows, ConnectionMethods, QueryResult};
 use crate::{DataResult, Result, SqlVal};
 
 mod fieldexpr;
@@ -200,7 +202,11 @@ impl<T: DataResult> Clone for Query<T> {
 
 /// Internal QueryOps helpers.
 #[allow(async_fn_in_trait)] // Not truly a public trait
-#[maybe_async_cfg::maybe(idents(ConnectionMethods(sync = "ConnectionMethods")), sync(), async())]
+#[maybe_async_cfg::maybe(
+    idents(ConnectionMethods(sync = "ConnectionMethods")),
+    sync(),
+    async(feature = "async")
+)]
 trait QueryOpsInternal<T> {
     async fn fetch(
         self,
@@ -212,7 +218,7 @@ trait QueryOpsInternal<T> {
     idents(ConnectionMethods(sync = "ConnectionMethods"), QueryOpsInternal),
     keep_self,
     sync(),
-    async()
+    async(feature = "async")
 )]
 impl<T: DataResult> QueryOpsInternal<T> for Query<T> {
     async fn fetch(
@@ -242,7 +248,7 @@ impl<T: DataResult> QueryOpsInternal<T> for Query<T> {
 #[maybe_async_cfg::maybe(
     idents(ConnectionMethods(sync = "ConnectionMethods"), QueryOpsInternal),
     sync(),
-    async()
+    async(feature = "async")
 )]
 pub trait QueryOps<T> {
     /// Executes the query against `conn` and returns the first result (if any).
@@ -263,7 +269,7 @@ pub trait QueryOps<T> {
     ),
     keep_self,
     sync(),
-    async()
+    async(feature = "async")
 )]
 impl<T: DataResult> QueryOps<T> for Query<T> {
     async fn load_first(self, conn: &impl ConnectionMethods) -> Result<Option<T>> {

--- a/butane_core/src/util.rs
+++ b/butane_core/src/util.rs
@@ -14,7 +14,7 @@ pub fn get_or_init_once_lock<T>(cell: &OnceLock<T>, f: impl FnOnce() -> Result<T
     }
 }
 
-/// If the given `OnceLock` is already intialized, return the value.
+/// If the given `OnceLock` is already initialized, return the value.
 /// Otherwise, invoke `f` and store the value.
 #[cfg(feature = "async")]
 pub async fn get_or_init_once_lock_async<T, Fut>(

--- a/butane_core/src/util.rs
+++ b/butane_core/src/util.rs
@@ -14,6 +14,8 @@ pub fn get_or_init_once_lock<T>(cell: &OnceLock<T>, f: impl FnOnce() -> Result<T
     }
 }
 
+/// If the given `OnceLock` is already intialized, return the value.
+/// Otherwise, invoke `f` and store the value.
 #[cfg(feature = "async")]
 pub async fn get_or_init_once_lock_async<T, Fut>(
     cell: &OnceLock<T>,

--- a/butane_core/src/util.rs
+++ b/butane_core/src/util.rs
@@ -14,6 +14,7 @@ pub fn get_or_init_once_lock<T>(cell: &OnceLock<T>, f: impl FnOnce() -> Result<T
     }
 }
 
+#[cfg(feature = "async")]
 pub async fn get_or_init_once_lock_async<T, Fut>(
     cell: &OnceLock<T>,
     f: impl FnOnce() -> Fut,

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
-butane = { features = ["pg", "sqlite"], workspace = true }
+butane = { features = ["async", "pg", "sqlite"], workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
-butane = { features = ["async", "pg", "sqlite"], workspace = true }
+butane = { features = ["async", "async-adapter", "pg", "sqlite"], workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -22,7 +22,7 @@ doc = false
 doc = false
 
 [features]
-default = ["pg", "sqlite", "sqlite-bundled"]
+default = ["sqlite", "sqlite-bundled"]
 pg = ["butane/pg"]
 sqlite = ["butane/sqlite"]
 sqlite-bundled = ["butane/sqlite-bundled"]

--- a/examples/getting_started_async/Cargo.toml
+++ b/examples/getting_started_async/Cargo.toml
@@ -36,7 +36,7 @@ sqlite = ["butane/sqlite"]
 sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
-butane = {features = ["async"], workspace = true}
+butane = {features = ["async", "async-adapter"], workspace = true}
 tokio = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]

--- a/examples/getting_started_async/Cargo.toml
+++ b/examples/getting_started_async/Cargo.toml
@@ -36,7 +36,7 @@ sqlite = ["butane/sqlite"]
 sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
-butane.workspace = true
+butane = {features = ["async"], workspace = true}
 tokio = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]

--- a/examples/newtype/Cargo.toml
+++ b/examples/newtype/Cargo.toml
@@ -15,7 +15,7 @@ sqlite = ["butane/sqlite"]
 sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
-butane = {workspace = true, features = ["async"]}
+butane = {workspace = true, features = ["async", "async-adapter"]}
 fake = { workspace = true, features = ["chrono", "derive", "uuid"] }
 garde = { version = "*", features = ["derive"] }
 serde.workspace = true

--- a/examples/newtype/Cargo.toml
+++ b/examples/newtype/Cargo.toml
@@ -15,7 +15,7 @@ sqlite = ["butane/sqlite"]
 sqlite-bundled = ["butane/sqlite-bundled"]
 
 [dependencies]
-butane.workspace = true
+butane = {workspace = true, features = ["async"]}
 fake = { workspace = true, features = ["chrono", "derive", "uuid"] }
 garde = { version = "*", features = ["derive"] }
 serde.workspace = true


### PR DESCRIPTION
Add `async` (for async overall) and `async-adapter` (for the ability to use naturally-sync backends like sqlite from async) features