### PR TITLE
Run butane-core tests with async-adapter feature

### DIFF
--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -59,7 +59,7 @@ thiserror = "1.0"
 uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
-butane_core = { workspace = true, features = ["log"] }
+butane_core = { workspace = true, features = ["log", "async-adapter"] }
 assert_matches = "1.5"
 butane_test_helper = { workspace = true }
 butane_test_macros.workspace = true


### PR DESCRIPTION
Running `butane_core> cargo test` fails

connection_not_closed_async_sqlite & debug_connection_async_sqlite fail if this feature isnt enabled.

Skipping these two tests only when `async-adapter` isnt enabled looks like a lot of work for not much benefit, over always running tests with the feature enabled.