### PR TITLE
Fix crate version in getting_started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ In `Cargo.toml`, add a dependency on Butane:
 
 ``` toml
 [dependencies]
-butane = { version = "0.6", features=["pg", "sqlite"] }
+butane = { version = "0.7", features=["pg", "sqlite"] }
 ```
 
 This guide will focus on using SQLite initially, and use "pg" for


### PR DESCRIPTION
Getting started guide refers to version `0.6`, but `0.7` is live on crates.io
Pointed out in #285