### PR TITLE
Recognize more paths for String and Vec

### DIFF
--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -464,3 +464,14 @@ async fn tokio_spawn(conn: ConnectionAsync) {
         foo.save(&conn).await.unwrap();
     });
 }
+
+#[model]
+struct TypeVariantsTest {
+    id: i64,
+    str1: String,
+    str2: std::string::String,
+    str3: ::std::string::String,
+    blob1: Vec<u8>,
+    blob2: std::vec::Vec<u8>,
+    blob3: ::std::vec::Vec<u8>,
+}

--- a/butane_core/src/codegen/mod.rs
+++ b/butane_core/src/codegen/mod.rs
@@ -459,9 +459,15 @@ pub fn get_primitive_sql_type(ty: &syn::Type) -> Option<DeferredSqlType> {
         return some_known(SqlType::BigInt);
     } else if *ty == parse_quote!(f32) || *ty == parse_quote!(f64) {
         return some_known(SqlType::Real);
-    } else if *ty == parse_quote!(String) {
+    } else if *ty == parse_quote!(String)
+        || *ty == parse_quote!(std::string::String)
+        || *ty == parse_quote!(::std::string::String)
+    {
         return some_known(SqlType::Text);
-    } else if *ty == parse_quote!(Vec<u8>) {
+    } else if *ty == parse_quote!(Vec<u8>)
+        || *ty == parse_quote!(std::vec::Vec<u8>)
+        || *ty == parse_quote!(::std::vec::Vec<u8>)
+    {
         return some_known(SqlType::Blob);
     }
 


### PR DESCRIPTION
Recognize std::string::String, ::std::string::String, std::vec::Vec, and ::std::vec::Vec.

Fixes #298