### PR TITLE
Use nanosecond granularity on sqlite timestamp cols

### DIFF
--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -373,6 +373,8 @@ async fn cant_save_unsaved_fkey(conn: ConnectionAsync) {
 #[butane_test]
 async fn basic_time(conn: ConnectionAsync) {
     let mut now = Utc::now();
+    // Ensure we have a non-zero subsecond value so that the assert below confirms
+    // that the time is actually being saved with subsecond precision.
     while now.timestamp_subsec_nanos() == 0 {
         now = Utc::now();
     }
@@ -389,10 +391,7 @@ async fn basic_time(conn: ConnectionAsync) {
     if conn.backend_name() == "sqlite" {
         assert_eq!(time.utc, time2.utc);
     } else {
-        assert_eq!(
-            time.utc.timestamp_subsec_micros(),
-            time2.utc.timestamp_subsec_micros()
-        );
+        assert_eq!(time.utc.timestamp_micros(), time2.utc.timestamp_micros());
     }
 }
 

--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -372,7 +372,11 @@ async fn cant_save_unsaved_fkey(conn: ConnectionAsync) {
 #[cfg(feature = "datetime")]
 #[butane_test]
 async fn basic_time(conn: ConnectionAsync) {
-    let now = Utc::now();
+    let mut now = Utc::now();
+    while now.timestamp_subsec_nanos() == 0 {
+        now = Utc::now();
+    }
+
     let mut time = TimeHolder {
         id: 1,
         naive: now.naive_utc(),
@@ -382,9 +386,7 @@ async fn basic_time(conn: ConnectionAsync) {
     time.save(&conn).await.unwrap();
 
     let time2 = TimeHolder::get(&conn, 1).await.unwrap();
-    // Note, we don't just compare the objects directly because we
-    // lose some precision when we go to the database.
-    assert_eq!(time.utc.timestamp(), time2.utc.timestamp());
+    assert_eq!(time.utc, time2.utc);
 }
 
 #[butane_test]

--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -386,7 +386,14 @@ async fn basic_time(conn: ConnectionAsync) {
     time.save(&conn).await.unwrap();
 
     let time2 = TimeHolder::get(&conn, 1).await.unwrap();
-    assert_eq!(time.utc, time2.utc);
+    if conn.backend_name() == "sqlite" {
+        assert_eq!(time.utc, time2.utc);
+    } else {
+        assert_eq!(
+            time.utc.timestamp_subsec_micros(),
+            time2.utc.timestamp_subsec_micros()
+        );
+    }
 }
 
 #[butane_test]

--- a/butane_core/src/db/sqlite.rs
+++ b/butane_core/src/db/sqlite.rs
@@ -24,7 +24,7 @@ use crate::query::{BoolExpr, Order};
 use crate::{debug, query, Error, Result, SqlType, SqlVal, SqlValRef};
 
 #[cfg(feature = "datetime")]
-const SQLITE_DT_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
+const SQLITE_DT_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.f";
 
 /// The name of the sqlite backend.
 pub const BACKEND_NAME: &str = "sqlite";


### PR DESCRIPTION
And revise timestamp test to require nanoseconds for sqlite, and microseconds for pg
