### PR TITLE
Fix clippy lints and update lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "fake"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b591050272097cc85b2f3c1cc4817ba4560057d10fcae6f7339f1cf622da0a0f"
+checksum = "2f5f203b70a419cb8880d1cfe6bebe488add0a0307d404e9f24021e5fd864b80"
 dependencies = [
  "chrono",
  "deunicode",
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1049,9 +1049,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c102670231191d07d37a35af3eb77f1f0dbf7a71be51a962dcd57ea607be7260"
+checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
 dependencies = [
  "jiff-static",
  "log",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdde31a9d349f1b1f51a0b3714a5940ac022976f4b49485fc04be052b183b4c"
+checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1180,9 +1180,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
 ]
@@ -1279,9 +1279,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1311,9 +1311,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -1664,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -1723,9 +1723,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -1883,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -2037,9 +2037,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2332,11 +2332,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2344,6 +2370,24 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/butane/src/db/mod.rs
+++ b/butane/src/db/mod.rs
@@ -3,14 +3,14 @@
 //! The different ways of referring to a database handle may present
 //! some initial confusion.
 //! * `ConnectionMethods` is a trait containing the methods available on a database connection or a transaction.
-//!    Most methods on a [DataObject][crate::DataObject] or a [Query][crate::query::Query] require an
-//!    implementation of `ConnectionMethods`.
+//!   Most methods on a [DataObject][crate::DataObject] or a [Query][crate::query::Query] require an
+//!   implementation of `ConnectionMethods`.
 //! * `BackendConnection` is a trait representing a direct connection to a database backend. It is a superset
 //!   of `ConnectionMethods` and also includes the ability to create a transaction.
 //! * `Transaction` is a struct representing a database transaction. It implements `ConnectionMethods`.
 //! * `Connection` is a convenience struct containing a boxed `BackendConnection`. It cannot do anything other than
-//!    what a `BackendConnection` can do, but allows using a single concrete type that is not tied to a particular
-//!    database backend. It is returned by the `connect` method.
+//!   what a `BackendConnection` can do, but allows using a single concrete type that is not tied to a particular
+//!   database backend. It is returned by the `connect` method.
 
 pub use butane_core::db::*;
 

--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -30,9 +30,9 @@ mod filter;
 /// * `#[table = "NAME"]` used on the struct to specify the name of the table (defaults to struct name)
 /// * `#[pk]` on a field to specify that it is the primary key.
 /// * `#[unique]` on a field indicates that the field's value must be unique
-///    (perhaps implemented as the SQL UNIQUE constraint by some backends).
+///   (perhaps implemented as the SQL UNIQUE constraint by some backends).
 /// * `#[default]` should be used on fields added by later migrations to avoid errors on existing objects.
-///     Unnecessary if the new field is an `Option<>`
+///   Unnecessary if the new field is an `Option<>`
 ///
 /// For example
 /// ```ignore
@@ -105,13 +105,13 @@ pub fn dataresult(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   matches. For example, to find all posts made in blogs by people
 ///   named "Pete" we might say `filter!(Post, `blog.matches(author == "Pete"))`.
 /// * `contains`: Essentially the many-to-many version of `matches`.
-///    Parameter is a sub-expression. Use with a [`Many`]
-///    field to evaluate as true if one of the many referents matches
-///    the given expression. For example, in a blog post model with a field
-///    `tags: Many<Tag>` we could filter to posts with a "cats" with
-///    the following `tags.contains(tag == "cats"). If the expression
-///    is single literal, it is assumed to be used to match the
-///    primary key.
+///   Parameter is a sub-expression. Use with a [`Many`]
+///   field to evaluate as true if one of the many referents matches
+///   the given expression. For example, in a blog post model with a field
+///   `tags: Many<Tag>` we could filter to posts with a "cats" with
+///   the following `tags.contains(tag == "cats"). If the expression
+///   is single literal, it is assumed to be used to match the
+///   primary key.
 ///
 /// # Examples
 /// ```ignore
@@ -259,7 +259,7 @@ pub fn derive_field_type(input: TokenStream) -> TokenStream {
             ..
         })
         | syn::Data::Struct(syn::DataStruct {
-            fields: syn::Fields::Unit { .. },
+            fields: syn::Fields::Unit,
             ..
         }) => derive_field_type_with_json(ident),
         syn::Data::Enum(data_enum) => derive_field_type_for_enum(ident, data_enum),

--- a/butane_core/src/db/mod.rs
+++ b/butane_core/src/db/mod.rs
@@ -3,14 +3,14 @@
 //! The different ways of referring to a database handle may present
 //! some initial confusion.
 //! * `ConnectionMethods` is a trait containing the methods available on a database connection or a transaction.
-//!    Most methods on a [DataObject][crate::DataObject] or a [Query][crate::query::Query] require an
-//!    implementation of `ConnectionMethods`.
+//!   Most methods on a [DataObject][crate::DataObject] or a [Query][crate::query::Query] require an
+//!   implementation of `ConnectionMethods`.
 //! * `BackendConnection` is a trait representing a direct connection to a database backend. It is a superset
 //!   of `ConnectionMethods` and also includes the ability to create a transaction.
 //! * `Transaction` is a struct representing a database transaction. It implements `ConnectionMethods`.
 //! * `Connection` is a convenience struct containing a boxed `BackendConnection`. It cannot do anything other than
-//!    what a `BackendConnection` can do, but allows using a single concrete type that is not tied to a particular
-//!    database backend. It is returned by the `connect` method.
+//!   what a `BackendConnection` can do, but allows using a single concrete type that is not tied to a particular
+//!   database backend. It is returned by the `connect` method.
 
 #![allow(missing_docs)]
 


### PR DESCRIPTION
Removes two recent CVEs from the lock file
- RUSTSEC-2025-0022
- RUSTSEC-2025-0023