### PR TITLE
Remove butane_core self-dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,6 @@ version = "0.8.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "butane_core",
  "butane_test_helper",
  "butane_test_macros",
  "bytes",

--- a/butane_core/Cargo.toml
+++ b/butane_core/Cargo.toml
@@ -58,7 +58,6 @@ thiserror = "2.0"
 uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
-butane_core = { workspace = true, features = ["log", "async-adapter"] }
 assert_matches = "1.5"
 butane_test_helper = { workspace = true, default-features = false, features = ["sqlite", "pg"] }
 butane_test_macros.workspace = true


### PR DESCRIPTION
Cargo publish now barfs on this, for details see
https://github.com/rust-lang/cargo/issues/15151

The `async-adapter` specification was added in #281 but is no longer necessary because it ends up transitively being included anyway through the `butane_test_helper` dev dependency.