### PR TITLE
impl PartialEq<T> for AutoPk<T>

### DIFF
--- a/butane_core/src/autopk.rs
+++ b/butane_core/src/autopk.rs
@@ -88,6 +88,16 @@ impl<T: PrimaryKeyType> PartialEq for AutoPk<T> {
     }
 }
 
+impl<T: PrimaryKeyType> PartialEq<T> for AutoPk<T> {
+    fn eq(&self, other: &T) -> bool {
+        if !self.is_valid() || !other.is_valid() {
+            false
+        } else {
+            self.inner.as_ref().eq(&Some(other))
+        }
+    }
+}
+
 impl<T: PrimaryKeyType> FieldType for AutoPk<T> {
     const SQLTYPE: SqlType = T::SQLTYPE;
     /// Reference type. Used for ergonomics with String (which has

--- a/butane_core/src/query/mod.rs
+++ b/butane_core/src/query/mod.rs
@@ -21,7 +21,7 @@ pub use fieldexpr::{DataOrd, FieldExpr, ManyFieldExpr};
 type TblName = Cow<'static, str>;
 
 /// Abstract representation of a database expression.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Expr {
     /// A column, referenced by name.
     Column(&'static str),
@@ -34,7 +34,7 @@ pub enum Expr {
 }
 
 /// Abstract representation of a boolean expression.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BoolExpr {
     True,
     Eq(&'static str, Expr),
@@ -84,7 +84,7 @@ pub struct Order {
     pub column: &'static str,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Join {
     /// Inner join `join_table` where `col1` is equal to
     /// `col2`
@@ -95,7 +95,7 @@ pub enum Join {
     },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Column {
     table: Option<TblName>,
     name: &'static str,


### PR DESCRIPTION
Allows comparing an  `AutoPk` field to an inner value in a `filter!` or `query!` invocation.

Also implements PartialEq for `Expr`, `BoolExpr`, and friends to allow their comparisons in tests.

Fixes #339