### PR TITLE
Add support for dates

### DIFF
--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -423,7 +423,7 @@ async fn date_as_pk(conn: ConnectionAsync) {
         .await
         .unwrap();
 
-    assert_eq!(holder.id, holder2.id);
+    assert_eq!(holder, holder2);
 }
 
 #[butane_test]

--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -405,7 +405,7 @@ async fn basic_time(conn: ConnectionAsync) {
 #[cfg(feature = "datetime")]
 #[model]
 #[derive(Debug, Default, PartialEq, Clone)]
-struct TimeHolderWithDatePk {
+struct DateHolder {
     pub id: NaiveDate,
 }
 
@@ -414,12 +414,12 @@ struct TimeHolderWithDatePk {
 async fn date_as_pk(conn: ConnectionAsync) {
     let now = Utc::now();
 
-    let mut holder = TimeHolderWithDatePk {
+    let mut holder = DateHolder {
         id: now.date_naive(),
     };
     holder.save(&conn).await.unwrap();
 
-    let holder2 = TimeHolderWithDatePk::get(&conn, now.date_naive())
+    let holder2 = DateHolder::get(&conn, now.date_naive())
         .await
         .unwrap();
 

--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -419,9 +419,7 @@ async fn date_as_pk(conn: ConnectionAsync) {
     };
     holder.save(&conn).await.unwrap();
 
-    let holder2 = DateHolder::get(&conn, now.date_naive())
-        .await
-        .unwrap();
+    let holder2 = DateHolder::get(&conn, now.date_naive()).await.unwrap();
 
     assert_eq!(holder, holder2);
 }

--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -6,7 +6,11 @@ use butane::{butane_type, find, find_async, model, query, AutoPk, ForeignKey};
 use butane_test_helper::*;
 use butane_test_macros::butane_test;
 #[cfg(feature = "datetime")]
-use chrono::{naive::{NaiveDate, NaiveDateTime}, offset::Utc, DateTime};
+use chrono::{
+    naive::{NaiveDate, NaiveDateTime},
+    offset::Utc,
+    DateTime,
+};
 #[cfg(feature = "sqlite")]
 use rusqlite;
 use std::ops::Deref;
@@ -108,7 +112,7 @@ struct TimeHolder {
     pub naive: NaiveDateTime,
     pub utc: DateTime<Utc>,
     pub when: chrono::DateTime<Utc>,
-    pub date: NaiveDate
+    pub date: NaiveDate,
 }
 
 #[butane_test]
@@ -415,7 +419,9 @@ async fn date_as_pk(conn: ConnectionAsync) {
     };
     holder.save(&conn).await.unwrap();
 
-    let holder2 = TimeHolderWithDatePk::get(&conn, now.date_naive()).await.unwrap();
+    let holder2 = TimeHolderWithDatePk::get(&conn, now.date_naive())
+        .await
+        .unwrap();
 
     assert_eq!(holder.id, holder2.id);
 }

--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -6,7 +6,7 @@ use butane::{butane_type, find, find_async, model, query, AutoPk, ForeignKey};
 use butane_test_helper::*;
 use butane_test_macros::butane_test;
 #[cfg(feature = "datetime")]
-use chrono::{naive::NaiveDateTime, offset::Utc, DateTime};
+use chrono::{naive::{NaiveDate, NaiveDateTime}, offset::Utc, DateTime};
 #[cfg(feature = "sqlite")]
 use rusqlite;
 use std::ops::Deref;
@@ -108,6 +108,7 @@ struct TimeHolder {
     pub naive: NaiveDateTime,
     pub utc: DateTime<Utc>,
     pub when: chrono::DateTime<Utc>,
+    pub date: NaiveDate
 }
 
 #[butane_test]
@@ -383,6 +384,7 @@ async fn basic_time(conn: ConnectionAsync) {
         naive: now.naive_utc(),
         utc: now,
         when: now,
+        date: now.date_naive(),
     };
     time.save(&conn).await.unwrap();
 
@@ -392,6 +394,8 @@ async fn basic_time(conn: ConnectionAsync) {
     } else {
         assert_eq!(time.utc.timestamp_micros(), time2.utc.timestamp_micros());
     }
+
+    assert_eq!(time.date, time2.date);
 }
 
 #[butane_test]

--- a/butane/tests/basic.rs
+++ b/butane/tests/basic.rs
@@ -398,6 +398,28 @@ async fn basic_time(conn: ConnectionAsync) {
     assert_eq!(time.date, time2.date);
 }
 
+#[cfg(feature = "datetime")]
+#[model]
+#[derive(Debug, Default, PartialEq, Clone)]
+struct TimeHolderWithDatePk {
+    pub id: NaiveDate,
+}
+
+#[cfg(feature = "datetime")]
+#[butane_test]
+async fn date_as_pk(conn: ConnectionAsync) {
+    let now = Utc::now();
+
+    let mut holder = TimeHolderWithDatePk {
+        id: now.date_naive(),
+    };
+    holder.save(&conn).await.unwrap();
+
+    let holder2 = TimeHolderWithDatePk::get(&conn, now.date_naive()).await.unwrap();
+
+    assert_eq!(holder.id, holder2.id);
+}
+
 #[butane_test]
 async fn basic_load_first(conn: ConnectionAsync) {
     //create

--- a/butane_core/src/codegen/mod.rs
+++ b/butane_core/src/codegen/mod.rs
@@ -499,6 +499,7 @@ pub fn get_primitive_sql_type(ty: &syn::Type) -> Option<DeferredSqlType> {
                         return some_known(SqlType::Timestamp);
                     }
                 }
+                "NaiveDate" => return some_known(SqlType::Date),
                 _ => {}
             }
         }
@@ -588,6 +589,8 @@ fn sqltype_from_name(name: &Ident) -> Option<TypeIdentifier> {
         "Blob" => return some_id(SqlType::Blob),
         #[cfg(feature = "json")]
         "Json" => return some_id(SqlType::Json),
+        #[cfg(feature = "datetime")]
+        "Date" => return some_id(SqlType::Date),
         #[cfg(feature = "datetime")]
         "Timestamp" => return some_id(SqlType::Timestamp),
         _ => (),

--- a/butane_core/src/db/helper.rs
+++ b/butane_core/src/db/helper.rs
@@ -308,7 +308,7 @@ pub fn sql_literal_value(val: &SqlVal) -> Result<String> {
         #[cfg(feature = "json")]
         Json(val) => Ok(format!("{val}")),
         #[cfg(feature = "datetime")]
-        Date(val) => Ok(format!("'{}'", val.format("'%Y-%m-%d'").to_string())),
+        Date(val) => Ok(format!("'{}'", val.format("'%Y-%m-%d'"))),
         #[cfg(feature = "datetime")]
         Timestamp(ndt) => Ok(ndt.format("'%Y-%m-%dT%H:%M:%S%.f'").to_string()),
         Custom(val) => Err(Error::LiteralForCustomUnsupported(*(*val).clone())),

--- a/butane_core/src/db/helper.rs
+++ b/butane_core/src/db/helper.rs
@@ -240,6 +240,8 @@ pub fn column_default(col: &AColumn) -> Result<SqlVal> {
             SqlType::Timestamp => {
                 SqlVal::Timestamp(chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc())
             }
+            #[cfg(feature = "datetime")]
+            SqlType::Date => SqlVal::Date(chrono::naive::NaiveDate::from_ymd_opt(1, 1, 1).unwrap()),
             SqlType::Custom(_) => return Err(Error::NoCustomDefault),
         },
         TypeIdentifier::Name(_) => return Err(Error::NoCustomDefault),
@@ -305,6 +307,8 @@ pub fn sql_literal_value(val: &SqlVal) -> Result<String> {
         Blob(val) => Ok(format!("x'{}'", hex::encode_upper(val))),
         #[cfg(feature = "json")]
         Json(val) => Ok(format!("{val}")),
+        #[cfg(feature = "datetime")]
+        Date(val) => Ok(format!("'{}'", val.format("'%Y-%m-%d'").to_string())),
         #[cfg(feature = "datetime")]
         Timestamp(ndt) => Ok(ndt.format("'%Y-%m-%dT%H:%M:%S%.f'").to_string()),
         Custom(val) => Err(Error::LiteralForCustomUnsupported(*(*val).clone())),

--- a/butane_core/src/db/pg.rs
+++ b/butane_core/src/db/pg.rs
@@ -447,6 +447,8 @@ impl postgres::types::ToSql for SqlValRef<'_> {
             #[cfg(feature = "json")]
             Json(v) => v.to_sql_checked(requested_ty, out),
             #[cfg(feature = "datetime")]
+            Date(v) => v.to_sql_checked(requested_ty, out),
+            #[cfg(feature = "datetime")]
             Timestamp(dt) => dt.to_sql_checked(requested_ty, out),
             Null => Ok(postgres::types::IsNull::Yes),
             Custom(SqlValRefCustom::PgToSql { ty, tosql }) => {
@@ -709,6 +711,8 @@ fn col_sqltype(col: &AColumn) -> Result<Cow<str>> {
                     SqlType::Real => Cow::Borrowed("DOUBLE PRECISION"),
                     SqlType::Text => Cow::Borrowed("TEXT"),
                     #[cfg(feature = "datetime")]
+                    SqlType::Date => Cow::Borrowed("DATE"),
+                    #[cfg(feature = "datetime")]
                     SqlType::Timestamp => Cow::Borrowed("TIMESTAMP"),
                     SqlType::Blob => Cow::Borrowed("BYTEA"),
                     #[cfg(feature = "json")]
@@ -903,6 +907,8 @@ fn pgtype_for_val(val: &SqlVal) -> postgres::types::Type {
         Some(SqlType::Blob) => postgres::types::Type::BYTEA,
         #[cfg(feature = "json")]
         Some(SqlType::Json) => postgres::types::Type::JSON,
+        #[cfg(feature = "datetime")]
+        Some(SqlType::Date) => postgres::types::Type::DATE,
         #[cfg(feature = "datetime")]
         Some(SqlType::Timestamp) => postgres::types::Type::TIMESTAMP,
         Some(SqlType::Custom(inner)) => match inner {

--- a/butane_core/src/db/pg.rs
+++ b/butane_core/src/db/pg.rs
@@ -5,7 +5,7 @@ use std::fmt::{Debug, Write};
 use async_trait::async_trait;
 use bytes::BufMut;
 #[cfg(feature = "datetime")]
-use chrono::{NaiveDateTime, NaiveDate};
+use chrono::{NaiveDate, NaiveDateTime};
 use futures_util::stream::StreamExt;
 use tokio_postgres as postgres;
 use tokio_postgres::GenericClient;

--- a/butane_core/src/db/pg.rs
+++ b/butane_core/src/db/pg.rs
@@ -5,7 +5,7 @@ use std::fmt::{Debug, Write};
 use async_trait::async_trait;
 use bytes::BufMut;
 #[cfg(feature = "datetime")]
-use chrono::NaiveDateTime;
+use chrono::{NaiveDateTime, NaiveDate};
 use futures_util::stream::StreamExt;
 use tokio_postgres as postgres;
 use tokio_postgres::GenericClient;
@@ -505,6 +505,8 @@ impl<'a> postgres::types::FromSql<'a> for SqlValRef<'a> {
             Type::JSONB => Ok(SqlValRef::Json(postgres::types::FromSql::from_sql(
                 ty, raw,
             )?)),
+            #[cfg(feature = "datetime")]
+            Type::DATE => Ok(SqlValRef::Date(NaiveDate::from_sql(ty, raw)?)),
             #[cfg(feature = "datetime")]
             Type::TIMESTAMP => Ok(SqlValRef::Timestamp(NaiveDateTime::from_sql(ty, raw)?)),
             _ => Ok(SqlValRef::Custom(SqlValRefCustom::PgBytes {

--- a/butane_core/src/db/sqlite.rs
+++ b/butane_core/src/db/sqlite.rs
@@ -9,7 +9,7 @@ use std::sync::Once;
 
 use async_trait::async_trait;
 #[cfg(feature = "datetime")]
-use chrono::naive::NaiveDateTime;
+use chrono::naive::{NaiveDateTime, NaiveDate};
 use fallible_streaming_iterator::FallibleStreamingIterator;
 use pin_project::pin_project;
 
@@ -25,6 +25,9 @@ use crate::{debug, query, Error, Result, SqlType, SqlVal, SqlValRef};
 
 #[cfg(feature = "datetime")]
 const SQLITE_DT_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.f";
+
+#[cfg(feature = "datetime")]
+const SQLITE_DATE_FORMAT: &str = "%Y-%m-%d";
 
 /// The name of the sqlite backend.
 pub const BACKEND_NAME: &str = "sqlite";
@@ -513,6 +516,11 @@ fn sqlvalref_to_sqlite<'a>(valref: &SqlValRef<'a>) -> rusqlite::types::ToSqlOutp
             .map(rusqlite::types::ToSqlOutput::from)
             .unwrap(),
         #[cfg(feature = "datetime")]
+        Date(date) => {
+            let f = date.format(SQLITE_DATE_FORMAT);
+            Owned(Value::Text(f.to_string()))
+        }
+        #[cfg(feature = "datetime")]
         Timestamp(dt) => {
             let f = dt.format(SQLITE_DT_FORMAT);
             Owned(Value::Text(f.to_string()))
@@ -625,6 +633,11 @@ fn sql_valref_from_rusqlite<'a>(
         SqlType::Text => SqlValRef::Text(val.as_str()?),
         #[cfg(feature = "json")]
         SqlType::Json => SqlValRef::Json(serde_json::from_str(val.as_str()?)?),
+        #[cfg(feature = "datetime")]
+        SqlType::Date => SqlValRef::Date(NaiveDate::parse_from_str(
+            val.as_str()?,
+            SQLITE_DATE_FORMAT,
+        )?),
         #[cfg(feature = "datetime")]
         SqlType::Timestamp => SqlValRef::Timestamp(NaiveDateTime::parse_from_str(
             val.as_str()?,
@@ -749,6 +762,8 @@ fn sqltype(ty: &SqlType) -> &'static str {
         SqlType::Blob => "BLOB",
         #[cfg(feature = "json")]
         SqlType::Json => "TEXT",
+        #[cfg(feature = "datetime")]
+        SqlType::Date => "TEXT",
         #[cfg(feature = "datetime")]
         SqlType::Timestamp => "TEXT",
         SqlType::Custom(_) => panic!("Custom types not supported by sqlite backend"),

--- a/butane_core/src/db/sqlite.rs
+++ b/butane_core/src/db/sqlite.rs
@@ -9,7 +9,7 @@ use std::sync::Once;
 
 use async_trait::async_trait;
 #[cfg(feature = "datetime")]
-use chrono::naive::{NaiveDateTime, NaiveDate};
+use chrono::naive::{NaiveDate, NaiveDateTime};
 use fallible_streaming_iterator::FallibleStreamingIterator;
 use pin_project::pin_project;
 

--- a/butane_core/src/lib.rs
+++ b/butane_core/src/lib.rs
@@ -364,6 +364,9 @@ pub enum SqlType {
     /// String
     Text,
     #[cfg(feature = "datetime")]
+    /// Date
+    Date,
+    #[cfg(feature = "datetime")]
     /// Timestamp
     Timestamp,
     /// Blob
@@ -383,6 +386,8 @@ impl std::fmt::Display for SqlType {
             BigInt => "big int",
             Real => "float",
             Text => "string",
+            #[cfg(feature = "datetime")]
+            Date => "date",
             #[cfg(feature = "datetime")]
             Timestamp => "timestamp",
             Blob => "blob",

--- a/butane_core/src/sqlval.rs
+++ b/butane_core/src/sqlval.rs
@@ -8,7 +8,10 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 #[cfg(feature = "datetime")]
-use chrono::{naive::{NaiveDate, NaiveDateTime}, DateTime};
+use chrono::{
+    naive::{NaiveDate, NaiveDateTime},
+    DateTime,
+};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "pg")]

--- a/butane_core/src/sqlval.rs
+++ b/butane_core/src/sqlval.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 #[cfg(feature = "datetime")]
-use chrono::{naive::NaiveDateTime, DateTime};
+use chrono::{naive::{NaiveDate, NaiveDateTime}, DateTime};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "pg")]
@@ -28,6 +28,8 @@ pub enum SqlValRef<'a> {
     #[cfg(feature = "json")]
     Json(serde_json::Value),
     #[cfg(feature = "datetime")]
+    Date(NaiveDate),
+    #[cfg(feature = "datetime")]
     Timestamp(NaiveDateTime), // NaiveDateTime is Copy
     Custom(SqlValRefCustom<'a>),
 }
@@ -41,6 +43,8 @@ impl SqlValRef<'_> {
             SqlValRef::BigInt(_) => Some(SqlType::BigInt),
             SqlValRef::Real(_) => Some(SqlType::Real),
             SqlValRef::Text(_) => Some(SqlType::Text),
+            #[cfg(feature = "datetime")]
+            SqlValRef::Date(_) => Some(SqlType::Date),
             #[cfg(feature = "datetime")]
             SqlValRef::Timestamp(_) => Some(SqlType::Timestamp),
             SqlValRef::Blob(_) => Some(SqlType::Blob),
@@ -78,6 +82,8 @@ pub enum SqlVal {
     Blob(Vec<u8>),
     #[cfg(feature = "json")]
     Json(serde_json::Value),
+    #[cfg(feature = "datetime")]
+    Date(NaiveDate),
     #[cfg(feature = "datetime")]
     Timestamp(NaiveDateTime),
     Custom(Box<SqlValCustom>),
@@ -161,6 +167,8 @@ impl SqlVal {
             SqlVal::Real(_) => Some(SqlType::Real),
             SqlVal::Text(_) => Some(SqlType::Text),
             #[cfg(feature = "datetime")]
+            SqlVal::Date(_) => Some(SqlType::Date),
+            #[cfg(feature = "datetime")]
             SqlVal::Timestamp(_) => Some(SqlType::Timestamp),
             SqlVal::Blob(_) => Some(SqlType::Blob),
             #[cfg(feature = "json")]
@@ -187,6 +195,8 @@ impl fmt::Display for SqlVal {
             Blob(val) => f.write_str(&hex::encode(val)),
             #[cfg(feature = "json")]
             Json(val) => f.write_str(val.as_str().unwrap()),
+            #[cfg(feature = "datetime")]
+            Date(val) => val.format("%Y-%m-%d").fmt(f),
             #[cfg(feature = "datetime")]
             Timestamp(val) => val.format("%+").fmt(f),
             Custom(val) => val.fmt(f),
@@ -254,6 +264,8 @@ impl From<SqlValRef<'_>> for SqlVal {
             #[cfg(feature = "json")]
             Json(v) => SqlVal::Json(v),
             #[cfg(feature = "datetime")]
+            Date(v) => SqlVal::Date(v),
+            #[cfg(feature = "datetime")]
             Timestamp(v) => SqlVal::Timestamp(v),
             Custom(v) => SqlVal::Custom(Box::new(v.into())),
         }
@@ -273,6 +285,8 @@ impl<'a> From<&'a SqlVal> for SqlValRef<'a> {
             Blob(v) => SqlValRef::Blob(v.as_ref()),
             #[cfg(feature = "json")]
             Json(v) => SqlValRef::Json(v.to_owned()),
+            #[cfg(feature = "datetime")]
+            Date(v) => SqlValRef::Date(*v),
             #[cfg(feature = "datetime")]
             Timestamp(v) => SqlValRef::Timestamp(*v),
             Custom(v) => SqlValRef::Custom(v.as_valref()),
@@ -624,6 +638,28 @@ impl FieldType for DateTime<chrono::offset::Utc> {
 }
 #[cfg(feature = "datetime")]
 impl PrimaryKeyType for DateTime<chrono::offset::Utc> {}
+
+#[cfg(feature = "datetime")]
+impl_basic_from_sql!(NaiveDate, Date, Date);
+#[cfg(feature = "datetime")]
+impl ToSql for NaiveDate {
+    fn to_sql(&self) -> SqlVal {
+        SqlVal::Date(*self)
+    }
+    fn to_sql_ref(&self) -> SqlValRef<'_> {
+        SqlValRef::Date(*self)
+    }
+    fn into_sql(self) -> SqlVal {
+        SqlVal::Date(self)
+    }
+}
+#[cfg(feature = "datetime")]
+impl FieldType for NaiveDate {
+    const SQLTYPE: SqlType = SqlType::Date;
+    type RefType = str;
+}
+#[cfg(feature = "datetime")]
+impl PrimaryKeyType for NaiveDate {}
 
 impl ToSql for &str {
     fn to_sql(&self) -> SqlVal {

--- a/butane_test_helper/src/lib.rs
+++ b/butane_test_helper/src/lib.rs
@@ -324,7 +324,8 @@ pub async fn pg_setup() -> PgSetupData {
     log::trace!("starting pg_setup");
     // By default we set up a temporary, local postgres server just
     // for this test. This can be overridden by the environment
-    // variable BUTANE_PG_CONNSTR
+    // variable BUTANE_PG_CONNSTR (which must be a PostgreSQL KV-style
+    // string, not a URL, e.g. "host=localhost user=postgres").
     let connstr = match std::env::var("BUTANE_PG_CONNSTR") {
         Ok(connstr) => connstr,
         Err(_) => {


### PR DESCRIPTION
Closes #87

Adds support for dates, using PostgreSQL's `DATE` type and stored as `TEXT` in SQLite using the same format used in PostgreSQL. I didn't add support for `chrono::Date` since it's deprecated, so only `NaiveDate` is supported. Support for this is gated behind the `datetime` feature.

Usage:
```rs
use chrono::naive::NaiveDate;

#[model]
struct Table {
    pub date: NaiveDate,
}
```

TODO:
- [x] Add tests on the `TimeHolder` table at `butane/tests/basic.rs`.
- [x] I haven't been able to test this with PostgreSQL. I saw there's an `BUTANE_PG_CONNSTR` env var but when running `cargo test` with it I kept getting nonexistent test table errors, is there anything I'm missing?