### PR TITLE
Support is_in check in filter!/query!

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "*.table": "json"
     },
     "makefile.buildBeforeLaunch": false,
-    "makefile.configureOnOpen": false
+    "makefile.configureOnOpen": false,
+    "rust-analyzer.cargo.features": "all",
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,7 +2104,7 @@ checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/butane/tests/query.rs
+++ b/butane/tests/query.rs
@@ -281,7 +281,7 @@ async fn offset(conn: ConnectionAsync) {
 #[butane_test]
 async fn query_in(conn: ConnectionAsync) {
     blog::setup_blog(&conn).await;
-    let mut posts = query!(Post, title.inn("The Tiger", "Sir Charles")).load(&conn).await.unwrap();
+    let mut posts = query!(Post, title.is_in("The Tiger", "Sir Charles")).load(&conn).await.unwrap();
     assert_eq!(posts.len(), 2);
     posts.sort_by(|p1, p2| p1.id.partial_cmp(&p2.id).unwrap());
     assert_eq!(posts[0].title, "The Tiger");

--- a/butane/tests/query.rs
+++ b/butane/tests/query.rs
@@ -310,7 +310,7 @@ async fn query_autopk_by_integer(conn: ConnectionAsync) {
 #[butane_test]
 async fn query_in(conn: ConnectionAsync) {
     blog::setup_blog(&conn).await;
-    let mut posts = query!(Post, title.is_in("The Tiger", "Sir Charles"))
+    let mut posts = query!(Post, title.is_in(vec!["The Tiger", "Sir Charles"]))
         .load(&conn)
         .await
         .unwrap();

--- a/butane/tests/query.rs
+++ b/butane/tests/query.rs
@@ -318,4 +318,12 @@ async fn query_in(conn: ConnectionAsync) {
     posts.sort_by(|p1, p2| p1.id.partial_cmp(&p2.id).unwrap());
     assert_eq!(posts[0].title, "The Tiger");
     assert_eq!(posts[1].title, "Sir Charles");
+
+    // Ensure we can do the same thing with a variable
+    let titles = vec!["The Tiger", "Sir Charles"];
+    posts = query!(Post, title.is_in({ titles }))
+        .load(&conn)
+        .await
+        .unwrap();
+    assert_eq!(posts.len(), 2);
 }

--- a/butane/tests/query.rs
+++ b/butane/tests/query.rs
@@ -277,3 +277,13 @@ async fn offset(conn: ConnectionAsync) {
     assert_eq!(posts[0].title, "Sir Charles");
     assert_eq!(posts[1].title, "The Tiger");
 }
+
+#[butane_test]
+async fn query_in(conn: ConnectionAsync) {
+    blog::setup_blog(&conn).await;
+    let mut posts = query!(Post, title.inn("The Tiger", "Sir Charles")).load(&conn).await.unwrap();
+    assert_eq!(posts.len(), 2);
+    posts.sort_by(|p1, p2| p1.id.partial_cmp(&p2.id).unwrap());
+    assert_eq!(posts[0].title, "The Tiger");
+    assert_eq!(posts[1].title, "Sir Charles");
+}

--- a/butane/tests/query.rs
+++ b/butane/tests/query.rs
@@ -281,7 +281,13 @@ async fn offset(conn: ConnectionAsync) {
 #[butane_test]
 async fn query_in(conn: ConnectionAsync) {
     blog::setup_blog(&conn).await;
-    let mut posts = query!(Post, title.is_in("The Tiger", "Sir Charles")).load(&conn).await.unwrap();
+    Post::fields()
+        .title()
+        .is_in(vec!["The Tiger", "Sir Charles"]);
+    let mut posts = query!(Post, title.is_in("The Tiger", "Sir Charles"))
+        .load(&conn)
+        .await
+        .unwrap();
     assert_eq!(posts.len(), 2);
     posts.sort_by(|p1, p2| p1.id.partial_cmp(&p2.id).unwrap());
     assert_eq!(posts[0].title, "The Tiger");

--- a/butane/tests/query.rs
+++ b/butane/tests/query.rs
@@ -281,9 +281,6 @@ async fn offset(conn: ConnectionAsync) {
 #[butane_test]
 async fn query_in(conn: ConnectionAsync) {
     blog::setup_blog(&conn).await;
-    Post::fields()
-        .title()
-        .is_in(vec!["The Tiger", "Sir Charles"]);
     let mut posts = query!(Post, title.is_in("The Tiger", "Sir Charles"))
         .load(&conn)
         .await

--- a/butane_codegen/src/filter.rs
+++ b/butane_codegen/src/filter.rs
@@ -73,10 +73,14 @@ fn handle_call(fields: &impl ToTokens, mcall: &ExprMethodCall) -> TokenStream2 {
     }
 }
 
-fn handle_in<'a>(fields: &impl ToTokens, receiver: &Expr, exprs: impl Iterator<Item = &'a Expr>) -> TokenStream2 {
+fn handle_in<'a>(
+    fields: &impl ToTokens,
+    receiver: &Expr,
+    exprs: impl Iterator<Item = &'a Expr>,
+) -> TokenStream2 {
     let fex = fieldexpr(fields, receiver);
     let exprs_tokens = exprs.map(|expr| handle_expr(fields, expr));
-    quote!(#fex.inn(vec![#(butane::ToSql::to_sql(#exprs_tokens)),*]))
+    quote!(#fex.is_in(vec![#(#exprs_tokens),*]))
 }
 
 fn handle_matches(fields: &impl ToTokens, receiver: &Expr, expr: &Expr) -> TokenStream2 {

--- a/butane_codegen/src/filter.rs
+++ b/butane_codegen/src/filter.rs
@@ -64,23 +64,19 @@ fn handle_call(fields: &impl ToTokens, mcall: &ExprMethodCall) -> TokenStream2 {
         }
         _ => (),
     };
+    let first_arg = || mcall.args.first().unwrap();
     match method.as_str() {
-        "matches" => handle_matches(fields, &mcall.receiver, mcall.args.first().unwrap()),
-        "contains" => handle_contains(fields, &mcall.receiver, mcall.args.first().unwrap()),
-        "like" => handle_like(fields, &mcall.receiver, mcall.args.first().unwrap()),
-        "is_in" => handle_in(fields, &mcall.receiver, mcall.args.iter()),
+        "matches" => handle_matches(fields, &mcall.receiver, first_arg()),
+        "contains" => handle_contains(fields, &mcall.receiver, first_arg()),
+        "like" => handle_like(fields, &mcall.receiver, first_arg()),
+        "is_in" => handle_in(fields, &mcall.receiver, first_arg()),
         _ => make_compile_error!("Unknown method call {}", method),
     }
 }
 
-fn handle_in<'a>(
-    fields: &impl ToTokens,
-    receiver: &Expr,
-    exprs: impl Iterator<Item = &'a Expr>,
-) -> TokenStream2 {
+fn handle_in(fields: &impl ToTokens, receiver: &Expr, expr: &Expr) -> TokenStream2 {
     let fex = fieldexpr(fields, receiver);
-    let exprs_tokens = exprs.map(|expr| handle_expr(fields, expr));
-    quote!(#fex.is_in(vec![#(#exprs_tokens),*]))
+    quote!(#fex.is_in(#expr))
 }
 
 fn handle_matches(fields: &impl ToTokens, receiver: &Expr, expr: &Expr) -> TokenStream2 {

--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -112,6 +112,7 @@ pub fn dataresult(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   the following `tags.contains(tag == "cats"). If the expression
 ///   is single literal, it is assumed to be used to match the
 ///   primary key.
+/// * `is_in`: checks if a value is one of the provided parameters, e.g. `title.is_in("Foo", "Bar")`.
 ///
 /// # Examples
 /// ```ignore

--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -112,7 +112,7 @@ pub fn dataresult(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   the following `tags.contains(tag == "cats"). If the expression
 ///   is single literal, it is assumed to be used to match the
 ///   primary key.
-/// * `is_in`: checks if a value is one of the provided parameters, e.g. `title.is_in("Foo", "Bar")`.
+/// * `is_in`: checks if a value is one of the provided parameters, e.g. `title.is_in(vec!["Foo", "Bar"])`.
 ///
 /// # Examples
 /// ```ignore

--- a/butane_core/src/query/fieldexpr.rs
+++ b/butane_core/src/query/fieldexpr.rs
@@ -64,6 +64,11 @@ where
     {
         BoolExpr::Like(self.name, Expr::Val(val.to_sql()))
     }
+
+    pub fn is_in<U>(&self, vals: Vec<SqlVal>) -> BoolExpr
+    {
+        BoolExpr::In(self.name, vals)
+    }
 }
 impl<F: DataObject> FieldExpr<ForeignKey<F>> {
     pub fn subfilter(&self, q: BoolExpr) -> BoolExpr {

--- a/butane_core/src/query/fieldexpr.rs
+++ b/butane_core/src/query/fieldexpr.rs
@@ -10,6 +10,7 @@ use crate::DataObject;
 
 macro_rules! binary_op {
     ($func_name:ident, $bound:path, $cond:ident) => {
+        /// Creates a [BoolExpr] which evalutes this column against `val`.
         pub fn $func_name<U>(&self, val: &U) -> BoolExpr
         where
             T: $bound,
@@ -27,6 +28,7 @@ impl<T> DataOrd<T> for Option<T> where T: PartialOrd<T> + FieldType {}
 impl<T> DataOrd<T> for T where T: PartialOrd<T> + FieldType {}
 
 /// Used to implement the `query!` and `filter!` macros.
+/// Manual use of this type is not recommended, but not prohibited.
 #[derive(Clone, Debug)]
 pub struct FieldExpr<T>
 where
@@ -40,6 +42,7 @@ impl<T> FieldExpr<T>
 where
     T: Into<SqlVal>,
 {
+    // Creates a `FieldExpr` from its name.
     pub fn new(name: &'static str) -> Self {
         FieldExpr {
             name,
@@ -47,6 +50,7 @@ where
         }
     }
 
+    /// Returns the name of this field.
     pub fn name(&self) -> &'static str {
         self.name
     }
@@ -58,6 +62,9 @@ where
     binary_op!(le, DataOrd<U>, Le);
     binary_op!(ge, DataOrd<U>, Ge);
 
+    /// Creates a [BoolExpr] which will evaluate to true if
+    /// the value of this field is "like" `val`, where
+    /// "like" is evaluated as the SQL LIKE operator.
     pub fn like<U>(&self, val: U) -> BoolExpr
     where
         U: ToSql,
@@ -65,6 +72,8 @@ where
         BoolExpr::Like(self.name, Expr::Val(val.to_sql()))
     }
 
+    /// Creates a [BoolExpr] which will evaluate to true if
+    /// the value of this field is contained in `vals`.
     pub fn is_in<U: ToSql>(&self, vals: Vec<U>) -> BoolExpr {
         BoolExpr::In(self.name, vals.into_iter().map(|v| v.to_sql()).collect())
     }

--- a/butane_core/src/query/fieldexpr.rs
+++ b/butane_core/src/query/fieldexpr.rs
@@ -65,9 +65,8 @@ where
         BoolExpr::Like(self.name, Expr::Val(val.to_sql()))
     }
 
-    pub fn is_in<U>(&self, vals: Vec<SqlVal>) -> BoolExpr
-    {
-        BoolExpr::In(self.name, vals)
+    pub fn is_in<U: ToSql>(&self, vals: Vec<U>) -> BoolExpr {
+        BoolExpr::In(self.name, vals.into_iter().map(|v| v.to_sql()).collect())
     }
 }
 impl<F: DataObject> FieldExpr<ForeignKey<F>> {

--- a/butane_core/src/query/fieldexpr.rs
+++ b/butane_core/src/query/fieldexpr.rs
@@ -42,7 +42,7 @@ impl<T> FieldExpr<T>
 where
     T: Into<SqlVal>,
 {
-    // Creates a `FieldExpr` from its name.
+    /// Creates a `FieldExpr` from its name.
     pub fn new(name: &'static str) -> Self {
         FieldExpr {
             name,


### PR DESCRIPTION
`query::BoolExpr::In` has existed for some time. In SQL backends (all of them currently) this translates into an IN query. We did not expose this in the convenience macros however. 

This change exposes it with a synthetic `is_in` function supported by filter. Use like
`query!(Post, title.is_in("Foo", "Bar"))`

Syntax like `title in ("Foo", "Bar")` would arguably be more natural. We could explore that as a future enhancement, but it would be more work as currently the filter! macro parses its input using `syn`  as syntactically valid Rust.

Addresses #345
