### PR TITLE
Fix cleaning .butane when running tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 name = "butane"
 version = "0.8.0"
 dependencies = [
+ "butane",
  "butane_codegen",
  "butane_core",
  "butane_test_helper",

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -28,7 +28,8 @@ log = ["butane_core/log"]
 r2d2 = ["dep:r2d2"]
 tls = ["butane_core/tls"]
 uuid = ["butane_codegen/uuid", "butane_core/uuid"]
-# This feature is for testing only. It will delete the .butane directory. You probably don't want that.
+# This feature is for testing only. It will delete the .butane directory inside the butane crate, which only
+# exists when running tests.  It has no effect when running butane as a dependency.
 _auto_delete_dot_butane = []
 
 [dependencies]

--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -28,6 +28,8 @@ log = ["butane_core/log"]
 r2d2 = ["dep:r2d2"]
 tls = ["butane_core/tls"]
 uuid = ["butane_codegen/uuid", "butane_core/uuid"]
+# This feature is for testing only. It will delete the .butane directory. You probably don't want that.
+_auto_delete_dot_butane = []
 
 [dependencies]
 butane_codegen = { workspace = true }
@@ -36,6 +38,7 @@ r2d2 = { optional = true, workspace = true }
 deadpool = { optional = true, workspace = true }
 
 [dev-dependencies]
+butane = { features = ["_auto_delete_dot_butane"], workspace = true}
 butane_test_helper = { workspace = true, default-features = false, features = ["sqlite", "pg"] }
 butane_test_macros = { workspace = true }
 cfg-if = { workspace = true }

--- a/butane/build.rs
+++ b/butane/build.rs
@@ -1,16 +1,22 @@
 fn main() {
-    // This build.rs is only needed to help the tests
-    if std::env::var("CARGO_CFG_TEST").is_err() {
-        return;
-    }
-    println!("cargo:rerun-if-changed=tests");
+    println!("cargo:rerun-if-changed=tests/");
 
-    // This cleans the .butane/ directory which is generated when compiling the tests so that
-    // the tests do not encounter side effects from previous test runs.
-    // Currently the only way to remove stale items from the generated .butane/ directory is to
-    // delete it before the code is compiled.
-    // This means we can not rely on `butane clean` or the code behind it, because it hasnt
-    // been compiled yet.
+    // Note that #[cfg(test)] and CARGO_CFG_TEST do not work in build.rs
+    // See https://github.com/rust-lang/cargo/issues/4789
+    #[cfg(feature = "_auto_delete_dot_butane")]
+    {
+        clean_dot_butane();
+    }
+}
+
+/// This cleans the .butane/ directory which is generated when compiling the tests so that
+/// the tests do not encounter side effects from previous test runs.
+/// Currently the only way to remove stale items from the generated .butane/ directory is to
+/// delete it before the code is compiled.
+/// This means we can not rely on `butane clean` or the code behind it, because it hasnt
+/// been compiled yet.
+#[cfg(feature = "_auto_delete_dot_butane")]
+fn clean_dot_butane() {
     let dir = ".butane/";
     if std::path::Path::new(&dir).is_dir() {
         println!("cargo:warning=Deleting .butane directory");

--- a/example/build.rs
+++ b/example/build.rs
@@ -1,10 +1,16 @@
 fn main() {
-    // This cleans the .butane/ directory which is generated when compiling the tests so that
-    // the tests do not encounter side effects from previous test runs.
-    // Currently the only way to remove stale items from the generated .butane/ directory is to
-    // delete it before the code is compiled.
-    // This means we can not rely on `butane clean` or the code behind it, because it hasnt
-    // been compiled yet.
+    println!("cargo:rerun-if-changed=tests/");
+
+    clean_dot_butane();
+}
+
+/// This cleans the .butane/ directory which is generated when compiling the tests so that
+/// the tests do not encounter side effects from previous test runs.
+/// Currently the only way to remove stale items from the generated .butane/ directory is to
+/// delete it before the code is compiled.
+/// This means we can not rely on `butane clean` or the code behind it, because it hasnt
+/// been compiled yet.
+fn clean_dot_butane() {
     let dir = ".butane/";
     println!("cargo:rerun-if-changed={dir}");
     if std::path::Path::new(&dir).is_dir() {


### PR DESCRIPTION
`#[cfg(test)]` and `CARGO_CFG_TEST` do not work in `build.rs`.
See https://github.com/rust-lang/cargo/issues/4789 which also offers the solution adopted here.