### PR TITLE
Ensure all syn::Type are a syn::Path without qself

### DIFF
--- a/butane_codegen/src/lib.rs
+++ b/butane_codegen/src/lib.rs
@@ -246,8 +246,9 @@ pub fn derive_field_type(input: TokenStream) -> TokenStream {
         }) => {
             if unnamed.len() == 1 {
                 let field = unnamed.first().unwrap();
+                let path = codegen::extract_path_from_type(&field.ty);
                 if let Some(DeferredSqlType::KnownId(TypeIdentifier::Ty(sqltype))) =
-                    codegen::get_primitive_sql_type(&field.ty)
+                    codegen::get_primitive_sql_type(path)
                 {
                     return derive_field_type_for_newtype(ident, sqltype);
                 }

--- a/butane_core/src/codegen/dbobj.rs
+++ b/butane_core/src/codegen/dbobj.rs
@@ -4,8 +4,8 @@ use quote::{quote, quote_spanned, ToTokens};
 use syn::{spanned::Spanned, Field, ItemStruct, LitStr};
 
 use super::{
-    fields, get_autopk_sql_type, get_type_argument, is_auto, is_many_to_many, is_row_field,
-    make_ident_literal_str, make_lit, pk_field, MANY_TYNAMES,
+    extract_path_from_type, fields, get_autopk_sql_type, get_type_argument, is_auto,
+    is_many_to_many, is_row_field, make_ident_literal_str, make_lit, pk_field, MANY_TYNAMES,
 };
 use crate::migrations::adb::{DeferredSqlType, TypeIdentifier, MANY_SUFFIX};
 use crate::SqlType;
@@ -391,7 +391,8 @@ fn verify_fields(ast_struct: &ItemStruct) -> Option<TokenStream2> {
     let pk_field = pk_field.unwrap();
     for f in fields(ast_struct) {
         if is_auto(f) {
-            match get_autopk_sql_type(&f.ty) {
+            let path = extract_path_from_type(&f.ty);
+            match get_autopk_sql_type(path) {
                 Some(DeferredSqlType::KnownId(TypeIdentifier::Ty(SqlType::Int))) => (),
                 Some(DeferredSqlType::KnownId(TypeIdentifier::Ty(SqlType::BigInt))) => (),
                 _ => {

--- a/butane_core/src/codegen/migration.rs
+++ b/butane_core/src/codegen/migration.rs
@@ -1,8 +1,8 @@
 use syn::{Field, ItemStruct};
 
 use super::{
-    dbobj, fields, get_default, get_deferred_sql_type, get_many_sql_type, is_auto, is_foreign_key,
-    is_many_to_many, is_option, is_row_field, is_unique, pk_field,
+    dbobj, extract_path_from_type, fields, get_default, get_deferred_sql_type, get_many_sql_type,
+    is_auto, is_foreign_key, is_many_to_many, is_option, is_row_field, is_unique, pk_field,
 };
 use crate::migrations::adb::{create_many_table, AColumn, ARef, ATable, DeferredSqlType, TypeKey};
 use crate::migrations::{MigrationMut, MigrationsMut};
@@ -47,7 +47,8 @@ fn create_atables(ast_struct: &ItemStruct, config: &dbobj::Config) -> Vec<ATable
             .expect("db object fields must be named")
             .to_string();
         if is_row_field(f) {
-            let deferred_type = get_deferred_sql_type(&f.ty);
+            let path = extract_path_from_type(&f.ty);
+            let deferred_type = get_deferred_sql_type(path);
             let mut col = AColumn::new(
                 name,
                 deferred_type.clone(),
@@ -83,7 +84,8 @@ fn many_table(main_table_name: &str, many_field: &Field, pk_field: &Field) -> AT
         .as_ref()
         .expect("fields must be named")
         .to_string();
-    let pk_field_type = get_deferred_sql_type(&pk_field.ty);
+    let pk_field_path = extract_path_from_type(&pk_field.ty);
+    let pk_field_type = get_deferred_sql_type(pk_field_path);
 
     create_many_table(
         main_table_name,

--- a/butane_core/tests/codegen.rs
+++ b/butane_core/tests/codegen.rs
@@ -1,4 +1,6 @@
-use butane_core::codegen::{get_deferred_sql_type, make_ident_literal_str, make_lit};
+use butane_core::codegen::{
+    get_deferred_sql_type, get_primitive_sql_type, make_ident_literal_str, make_lit,
+};
 use butane_core::migrations::adb::{DeferredSqlType, TypeIdentifier, TypeKey};
 use butane_core::SqlType;
 use proc_macro2::Span;
@@ -19,67 +21,87 @@ fn make_litstr_from_str() {
 }
 
 #[test]
-fn test_get_deferred_sql_type() {
-    // primitive type
-    let type_path: syn::TypePath = syn::parse_quote!(i8);
-    let typ = syn::Type::Path(type_path);
-    let rv = get_deferred_sql_type(&typ);
+fn primitive_sql_type() {
+    let path: syn::Path = syn::parse_quote!(i8);
+    let rv = get_primitive_sql_type(&path).unwrap();
     if let DeferredSqlType::KnownId(TypeIdentifier::Ty(sql_type)) = rv {
         assert_eq!(sql_type, SqlType::Int);
     } else {
         panic!()
     }
 
-    let type_path: syn::TypePath = syn::parse_quote!(Option<i8>);
-    let typ = syn::Type::Path(type_path);
-    let rv = get_deferred_sql_type(&typ);
+    let path: syn::Path = syn::parse_quote!(Option<i8>);
+    assert!(get_primitive_sql_type(&path).is_none());
+}
+
+#[test]
+fn deferred_sql_type_primitive() {
+    let path: syn::Path = syn::parse_quote!(i8);
+    let rv = get_deferred_sql_type(&path);
     if let DeferredSqlType::KnownId(TypeIdentifier::Ty(sql_type)) = rv {
         assert_eq!(sql_type, SqlType::Int);
     } else {
         panic!()
     }
 
-    // custom types
-    let type_path: syn::TypePath = syn::parse_quote!(Foo);
-    let typ = syn::Type::Path(type_path);
-    let rv = get_deferred_sql_type(&typ);
+    let path: syn::Path = syn::parse_quote!(Option<i8>);
+    let rv = get_deferred_sql_type(&path);
+    if let DeferredSqlType::KnownId(TypeIdentifier::Ty(sql_type)) = rv {
+        assert_eq!(sql_type, SqlType::Int);
+    } else {
+        panic!()
+    }
+}
+
+#[test]
+fn deferred_sql_type_user_defined_types() {
+    let path: syn::Path = syn::parse_quote!(Foo);
+    let rv = get_deferred_sql_type(&path);
     if let DeferredSqlType::Deferred(TypeKey::CustomType(typ)) = rv {
         assert_eq!(typ, "Foo");
     } else {
         panic!()
     }
 
-    let type_path: syn::TypePath = syn::parse_quote!(Option<Foo>);
-    let typ = syn::Type::Path(type_path);
-    let rv = get_deferred_sql_type(&typ);
+    let path: syn::Path = syn::parse_quote!(Option<Foo>);
+    let rv = get_deferred_sql_type(&path);
     if let DeferredSqlType::Deferred(TypeKey::CustomType(typ)) = rv {
         assert_eq!(typ, "Foo");
     } else {
         panic!()
     }
-
-    // foreign keys to custom types
-    let type_path: syn::TypePath = syn::parse_quote!(butane::ForeignKey<Foo>);
-    let typ = syn::Type::Path(type_path);
-    let rv = get_deferred_sql_type(&typ);
+}
+#[test]
+fn deferred_sql_type_fkey() {
+    let path: syn::Path = syn::parse_quote!(butane::ForeignKey<Foo>);
+    let rv = get_deferred_sql_type(&path);
     assert_eq!(
         rv,
         DeferredSqlType::Deferred(TypeKey::PK("Foo".to_string()))
     );
 
-    let type_path: syn::TypePath = syn::parse_quote!(Option<butane::ForeignKey<Foo>>);
-    let typ = syn::Type::Path(type_path);
-    let rv = get_deferred_sql_type(&typ);
+    let path: syn::Path = syn::parse_quote!(Option<butane::ForeignKey<Foo>>);
+    let rv = get_deferred_sql_type(&path);
     assert_eq!(
         rv,
         DeferredSqlType::Deferred(TypeKey::PK("Foo".to_string()))
     );
 
-    let type_path: syn::TypePath = syn::parse_quote!(butane::Many<Foo>);
-    let typ = syn::Type::Path(type_path);
-    let rv = get_deferred_sql_type(&typ);
+    let path: syn::Path = syn::parse_quote!(butane::Many<Foo>);
+    let rv = get_deferred_sql_type(&path);
     assert_eq!(
         rv,
         DeferredSqlType::Deferred(TypeKey::CustomType("butane::Many<Foo>".into()))
     );
+}
+
+#[test]
+fn deferred_sql_type_many() {
+    let path: syn::Path = syn::parse_quote!(butane::Many<Foo>);
+    let rv = get_deferred_sql_type(&path);
+    if let DeferredSqlType::Deferred(TypeKey::CustomType(typ)) = rv {
+        assert_eq!(typ, "butane::Many<Foo>");
+    } else {
+        panic!()
+    }
 }


### PR DESCRIPTION
See https://docs.rs/syn/latest/syn/struct.TypePath.html which defines a `qself`, and I believe that use with a `qself` would break butane, and probably couldnt be used in the vast majority of the places where butane ForiegnKey & Many relationships appear.