### PR TITLE
Fix self-referential dev dependency

### DIFF
--- a/butane/Cargo.toml
+++ b/butane/Cargo.toml
@@ -40,7 +40,7 @@ r2d2 = { optional = true, workspace = true }
 deadpool = { optional = true, workspace = true }
 
 [dev-dependencies]
-butane = { features = ["_auto_delete_dot_butane"], workspace = true}
+butane = { features = ["_auto_delete_dot_butane"], path = "." }
 butane_test_helper = { workspace = true, default-features = false, features = ["sqlite", "pg"] }
 butane_test_macros = { workspace = true }
 cfg-if = { workspace = true }


### PR DESCRIPTION
The self-referential dev-dependency of the main butane crate prevents publishing to crates.io unless it references by path only. 
See  https://github.com/rust-lang/cargo/issues/4242 for more info