### PR TITLE
Fixed error in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -128,7 +128,6 @@ impl Post {
             tags: Many::default(),
             blog: blog.into(),
             byline: None,
-            likes: 0,
         }
     }
 }


### PR DESCRIPTION
Deleted `likes` attribute in the first definition of `Post` struct. It is used later in migration context.