### PR TITLE
Use Windows 2022 in CI & fix Rust 1.89 clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Setup PostgreSQL on Linux
       if: runner.os == 'Linux'
       run: |
+        set -ex
         sudo apt-get update
         sudo apt-get install -y postgresql
         sudo sed -i "s/scram-sha-256/trust/" /etc/postgresql/16/main/pg_hba.conf
@@ -51,6 +52,7 @@ jobs:
     - name: Setup PostgreSQL on MacOS
       if: runner.os == 'macOS'
       run: |
+        set -ex
         brew install postgresql
         initdb -D /usr/local/var/postgres
         pg_ctl -D /usr/local/var/postgres start
@@ -59,8 +61,8 @@ jobs:
         echo BUTANE_PG_CONNSTR="host=localhost user=postgres sslmode=disable port=5432" >> $GITHUB_ENV
     - name: Install PostgreSQL on Windows
       if: runner.os == 'Windows'
-      shell: bash
       run: |
+        set -ex
         choco install postgresql12 --force --params '/Password:root'
         echo "C:\Program Files\PostgreSQL\12\bin" >> $GITHUB_PATH
         echo "C:\Program Files\PostgreSQL\12\lib" >> $GITHUB_PATH
@@ -72,7 +74,7 @@ jobs:
       run: |
         choco install sqlite
         cd /D C:\ProgramData\chocolatey\lib\SQLite\tools
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         lib /machine:x64 /def:sqlite3.def /out:sqlite3.lib
         echo "C:\ProgramData\chocolatey\lib\SQLite\tools" >> $GITHUB_PATH
         echo "SQLITE3_LIB_DIR=C:\ProgramData\chocolatey\lib\SQLite\tools" >> $GITHUB_ENV
@@ -116,6 +118,7 @@ jobs:
         git diff --cached --exit-code
     - name: Run tests in examples
       run: |
+        set -ex
         cargo +stable test -p example --all-features
         cd examples
         for dir in *; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-13
-          - windows-2019
+          - windows-latest
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/butane_core/src/custom.rs
+++ b/butane_core/src/custom.rs
@@ -33,7 +33,7 @@ pub enum SqlValCustom {
 }
 
 impl SqlValCustom {
-    pub fn as_valref(&self) -> SqlValRefCustom {
+    pub fn as_valref(&self) -> SqlValRefCustom<'_> {
         match self {
             #[cfg(feature = "pg")]
             SqlValCustom::Pg { ty, data } => SqlValRefCustom::PgBytes {

--- a/butane_core/src/db/connmethods.rs
+++ b/butane_core/src/db/connmethods.rs
@@ -111,7 +111,7 @@ pub trait BackendRows {
     fn mapped<F, B>(self, f: F) -> MapDeref<Self, F>
     where
         Self: Sized,
-        F: FnMut(&(dyn BackendRow)) -> Result<B>,
+        F: FnMut(&dyn BackendRow) -> Result<B>,
     {
         MapDeref { it: self, f }
     }
@@ -126,7 +126,7 @@ pub struct MapDeref<I, F> {
 impl<I, F, B> fallible_iterator::FallibleIterator for MapDeref<I, F>
 where
     I: BackendRows,
-    F: FnMut(&(dyn BackendRow)) -> Result<B>,
+    F: FnMut(&dyn BackendRow) -> Result<B>,
 {
     type Item = B;
     type Error = crate::Error;
@@ -171,23 +171,23 @@ impl<T> BackendRows for VecRows<T>
 where
     T: BackendRow,
 {
-    fn next(&mut self) -> Result<Option<&(dyn BackendRow)>> {
+    fn next(&mut self) -> Result<Option<&dyn BackendRow>> {
         let ret = self.rows.get(self.idx);
         self.idx += 1;
         Ok(ret.map(|row| row as &dyn BackendRow))
     }
 
-    fn current(&self) -> Option<&(dyn BackendRow)> {
+    fn current(&self) -> Option<&dyn BackendRow> {
         self.rows.get(self.idx).map(|row| row as &dyn BackendRow)
     }
 }
 
 impl BackendRows for Box<dyn BackendRows + '_> {
-    fn next(&mut self) -> Result<Option<&(dyn BackendRow)>> {
+    fn next(&mut self) -> Result<Option<&dyn BackendRow>> {
         BackendRows::next(self.deref_mut())
     }
 
-    fn current(&self) -> Option<&(dyn BackendRow)> {
+    fn current(&self) -> Option<&dyn BackendRow> {
         self.deref().current()
     }
 }
@@ -200,7 +200,7 @@ pub(crate) struct VecRow {
 
 #[cfg(feature = "async-adapter")]
 impl VecRow {
-    fn new(original: &(dyn BackendRow), columns: &[Column]) -> Result<Self> {
+    fn new(original: &dyn BackendRow, columns: &[Column]) -> Result<Self> {
         if original.len() != columns.len() {
             return Err(crate::Error::BoundsError(
                 "row length doesn't match columns specifier length".into(),

--- a/butane_core/src/db/connmethods.rs
+++ b/butane_core/src/db/connmethods.rs
@@ -91,7 +91,7 @@ impl Column {
 /// Backend-specific row abstraction. Only implementors of new
 /// backends need use this trait directly.
 pub trait BackendRow {
-    fn get(&self, idx: usize, ty: SqlType) -> Result<SqlValRef>;
+    fn get(&self, idx: usize, ty: SqlType) -> Result<SqlValRef<'_>>;
     fn len(&self) -> usize;
     // clippy wants this method to exist
     fn is_empty(&self) -> bool {
@@ -220,7 +220,7 @@ impl VecRow {
 
 #[cfg(feature = "async-adapter")]
 impl BackendRow for VecRow {
-    fn get(&self, idx: usize, ty: SqlType) -> Result<SqlValRef> {
+    fn get(&self, idx: usize, ty: SqlType) -> Result<SqlValRef<'_>> {
         self.values
             .get(idx)
             .ok_or_else(|| crate::Error::BoundsError("idx out of bounds".into()))

--- a/butane_core/src/db/helper.rs
+++ b/butane_core/src/db/helper.rs
@@ -14,11 +14,11 @@ use crate::Error;
 use crate::{query, Result, SqlType, SqlVal};
 
 pub trait PlaceholderSource {
-    fn next_placeholder(&mut self) -> Cow<str>;
+    fn next_placeholder(&mut self) -> Cow<'_, str>;
 }
 
 /// Quotes the `word` if it is a reserved word.
-pub fn quote_reserved_word(word: &str) -> Cow<str> {
+pub fn quote_reserved_word(word: &str) -> Cow<'_, str> {
     if sqlparser::keywords::ALL_KEYWORDS.contains(&word.to_uppercase().as_str()) {
         format!("\"{}\"", word).into()
     } else {

--- a/butane_core/src/db/helper.rs
+++ b/butane_core/src/db/helper.rs
@@ -13,7 +13,9 @@ use crate::query::{BoolExpr::*, Expr, Join, Order, OrderDirection};
 use crate::Error;
 use crate::{query, Result, SqlType, SqlVal};
 
-pub trait PlaceholderSource {
+/// Trait for generating SQL placeholders.
+pub(crate) trait PlaceholderSource {
+    /// Returns the next placeholder for a parameterized query.
     fn next_placeholder(&mut self) -> Cow<'_, str>;
 }
 

--- a/butane_core/src/db/mod.rs
+++ b/butane_core/src/db/mod.rs
@@ -117,7 +117,7 @@ pub trait BackendConnection: ConnectionMethods + Debug + Send {
 )]
 #[async_trait]
 impl BackendConnection for Box<dyn BackendConnection> {
-    async fn transaction(&mut self) -> Result<Transaction> {
+    async fn transaction(&mut self) -> Result<Transaction<'_>> {
         self.deref_mut().transaction().await
     }
     fn backend(&self) -> Box<dyn Backend> {
@@ -299,7 +299,7 @@ impl ConnectionAsync {
 )]
 #[async_trait]
 impl BackendConnection for Connection {
-    async fn transaction(&mut self) -> Result<Transaction> {
+    async fn transaction(&mut self) -> Result<Transaction<'_>> {
         self.conn.transaction().await
     }
     fn backend(&self) -> Box<dyn Backend> {
@@ -690,7 +690,7 @@ impl TryFrom<&String> for ConnectionSpec {
     }
 }
 
-fn conn_complete_if_dir(path: &Path) -> Cow<Path> {
+fn conn_complete_if_dir(path: &Path) -> Cow<'_, Path> {
     if path.is_dir() {
         Cow::from(path.join("connection.json"))
     } else {

--- a/butane_core/src/db/pg.rs
+++ b/butane_core/src/db/pg.rs
@@ -140,7 +140,7 @@ impl Debug for PgConnection {
     }
 }
 
-type DynToSqlPg<'a> = (dyn postgres::types::ToSql + Sync + 'a);
+type DynToSqlPg<'a> = dyn postgres::types::ToSql + Sync + 'a;
 
 fn sqlval_for_pg_query(v: &SqlVal) -> &dyn postgres::types::ToSql {
     v as &dyn postgres::types::ToSql

--- a/butane_core/src/db/pg.rs
+++ b/butane_core/src/db/pg.rs
@@ -545,7 +545,7 @@ fn check_columns(row: &postgres::Row, cols: &[Column]) -> Result<()> {
 }
 
 impl BackendRow for postgres::Row {
-    fn get(&self, idx: usize, _ty: SqlType) -> Result<SqlValRef> {
+    fn get(&self, idx: usize, _ty: SqlType) -> Result<SqlValRef<'_>> {
         Ok(self.try_get(idx)?)
     }
     fn len(&self) -> usize {
@@ -695,7 +695,7 @@ fn drop_fkey_constraints(table: &ATable, column: &AColumn) -> Result<String> {
     modified_column.remove_reference();
     change_column(table, column, &modified_column)
 }
-fn col_sqltype(col: &AColumn) -> Result<Cow<str>> {
+fn col_sqltype(col: &AColumn) -> Result<Cow<'_, str>> {
     match col.typeid()? {
         TypeIdentifier::Name(name) => Ok(Cow::Owned(name)),
         TypeIdentifier::Ty(ty) => {
@@ -930,7 +930,7 @@ impl PgPlaceholderSource {
     }
 }
 impl helper::PlaceholderSource for PgPlaceholderSource {
-    fn next_placeholder(&mut self) -> Cow<str> {
+    fn next_placeholder(&mut self) -> Cow<'_, str> {
         let ret = Cow::Owned(format!("${}", self.n));
         self.n += 1;
         ret

--- a/butane_core/src/db/sqlite.rs
+++ b/butane_core/src/db/sqlite.rs
@@ -569,7 +569,7 @@ impl<'a> QueryAdapterInner<'a> {
         Ok(rows.next()?)
     }
 
-    fn current(self: Pin<&Self>) -> Option<&rusqlite::Row> {
+    fn current(self: Pin<&Self>) -> Option<&rusqlite::Row<'_>> {
         let this = self.project_ref();
         this.rows.as_ref().unwrap().get()
     }
@@ -604,7 +604,7 @@ impl BackendRows for QueryAdapter<'_> {
 }
 
 impl BackendRow for rusqlite::Row<'_> {
-    fn get(&self, idx: usize, ty: SqlType) -> Result<SqlValRef> {
+    fn get(&self, idx: usize, ty: SqlType) -> Result<SqlValRef<'_>> {
         sql_valref_from_rusqlite(self.get_ref(idx)?, &ty)
     }
     fn len(&self) -> usize {
@@ -751,7 +751,7 @@ fn define_constraint(column: &AColumn) -> String {
     }
 }
 
-fn col_sqltype(col: &AColumn) -> Cow<str> {
+fn col_sqltype(col: &AColumn) -> Cow<'_, str> {
     match col.typeid() {
         Ok(TypeIdentifier::Ty(ty)) => Cow::Borrowed(sqltype(&ty)),
         Ok(TypeIdentifier::Name(name)) => Cow::Owned(name),
@@ -911,7 +911,7 @@ impl SQLitePlaceholderSource {
     }
 }
 impl helper::PlaceholderSource for SQLitePlaceholderSource {
-    fn next_placeholder(&mut self) -> Cow<str> {
+    fn next_placeholder(&mut self) -> Cow<'_, str> {
         // sqlite placeholder is always a question mark.
         Cow::Borrowed("?")
     }

--- a/butane_core/src/fkey.rs
+++ b/butane_core/src/fkey.rs
@@ -153,7 +153,7 @@ impl<T> AsPrimaryKey<T> for ForeignKey<T>
 where
     T: DataObject,
 {
-    fn as_pk(&self) -> Cow<T::PKType> {
+    fn as_pk(&self) -> Cow<'_, T::PKType> {
         Cow::Owned(self.pk())
     }
 }

--- a/butane_core/src/lib.rs
+++ b/butane_core/src/lib.rs
@@ -89,7 +89,7 @@ pub mod internal {
 
         /// Returns the Sql values of all columns except not any auto columns.
         /// Used internally. You are unlikely to need to call this directly.
-        fn non_auto_values(&self, include_pk: bool) -> Vec<SqlValRef>;
+        fn non_auto_values(&self, include_pk: bool) -> Vec<SqlValRef<'_>>;
     }
 }
 

--- a/butane_core/src/migrations/fsmigrations.rs
+++ b/butane_core/src/migrations/fsmigrations.rs
@@ -311,11 +311,11 @@ impl Migration for FsMigration {
         Ok(db)
     }
 
-    fn migration_from(&self) -> Result<Option<Cow<str>>> {
+    fn migration_from(&self) -> Result<Option<Cow<'_, str>>> {
         Ok(self.info()?.from_name.map(Cow::from))
     }
 
-    fn name(&self) -> Cow<str> {
+    fn name(&self) -> Cow<'_, str> {
         // There should be no way our root has no name portion
         self.root.file_name().unwrap().to_string_lossy()
     }

--- a/butane_core/src/migrations/memmigrations.rs
+++ b/butane_core/src/migrations/memmigrations.rs
@@ -37,11 +37,11 @@ impl Migration for MemMigration {
         Ok(ret)
     }
 
-    fn migration_from(&self) -> Result<Option<Cow<str>>> {
+    fn migration_from(&self) -> Result<Option<Cow<'_, str>>> {
         Ok(self.from.as_ref().map(Cow::from))
     }
 
-    fn name(&self) -> Cow<str> {
+    fn name(&self) -> Cow<'_, str> {
         Cow::from(&self.name)
     }
 

--- a/butane_core/src/migrations/migration.rs
+++ b/butane_core/src/migrations/migration.rs
@@ -19,12 +19,12 @@ pub trait Migration: Debug + PartialEq {
     fn db(&self) -> Result<ADB>;
 
     /// Get the name of the migration before this one (if any).
-    fn migration_from(&self) -> Result<Option<Cow<str>>>
+    fn migration_from(&self) -> Result<Option<Cow<'_, str>>>
     where
         Self: Sized;
 
     /// The name of this migration.
-    fn name(&self) -> Cow<str>;
+    fn name(&self) -> Cow<'_, str>;
 
     /// The backend-specific commands to apply this migration.
     fn up_sql(&self, backend_name: &str) -> Result<Option<String>>;

--- a/butane_core/src/migrations/mod.rs
+++ b/butane_core/src/migrations/mod.rs
@@ -375,7 +375,7 @@ impl crate::internal::DataObjectInternal for ButaneMigration {
     fn pk_mut(&mut self) -> &mut impl PrimaryKeyType {
         &mut self.name
     }
-    fn non_auto_values(&self, include_pk: bool) -> Vec<SqlValRef> {
+    fn non_auto_values(&self, include_pk: bool) -> Vec<SqlValRef<'_>> {
         let mut values: Vec<SqlValRef<'_>> = Vec::with_capacity(2usize);
         if include_pk {
             values.push(self.name.to_sql_ref());

--- a/butane_core/src/sqlval.rs
+++ b/butane_core/src/sqlval.rs
@@ -330,7 +330,7 @@ pub trait PrimaryKeyType: FieldType + Clone + PartialEq + Sync {
 /// Trait for referencing the primary key for a given model. Used to
 /// implement ForeignKey equality tests.
 pub trait AsPrimaryKey<T: DataObject> {
-    fn as_pk(&self) -> Cow<<T as DataObject>::PKType>;
+    fn as_pk(&self) -> Cow<'_, <T as DataObject>::PKType>;
 }
 
 impl<P, T> AsPrimaryKey<T> for P
@@ -338,7 +338,7 @@ where
     P: PrimaryKeyType,
     T: DataObject<PKType = P>,
 {
-    fn as_pk(&self) -> Cow<P> {
+    fn as_pk(&self) -> Cow<'_, P> {
         Cow::Borrowed(self)
     }
 }


### PR DESCRIPTION
Fix Rust 1.89 lints and use latest windows as 2019 has been decommissioned.