### PR TITLE
Avoid CI post job cleanup errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,12 @@ jobs:
       with:
         toolchain: nightly
         components: rustfmt
-    - name: Add Rust nightly toolchain
+        cache: false
+    - name: Add Rust stable toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+        cache-workspaces: ". -> target"
     - name: Install tool binaries
       uses: taiki-e/install-action@v2
       with:


### PR DESCRIPTION
CI on main , eg. https://github.com/Electron100/butane/actions/runs/19359759236 , includes 14 errors similar to
```
[build (ubuntu-latest)](https://github.com/Electron100/butane/actions/runs/19359759236/job/55388672515#step:49:59)
Error: ENOENT: no such file or directory, opendir '/home/runner/work/butane/butane/target/tests/target'
```

https://github.com/actions-rust-lang/setup-rust-toolchain uses https://github.com/Swatinem/rust-cache , and very likely our CI is resulting two caching cleanups, so we can avoid one of those.

It is a bit strange that this PR fixes it, as the docs of rust-cache says this is the default
```
    # default: ". -> target"
    workspaces: ""
```

But explicitly adding that setting fixes it, as seen at https://github.com/Electron100/butane/actions/runs/19376713401?pr=427

No code change, not controversial.